### PR TITLE
Initial path tracer implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Vulkan 1.4 real-time 3D game engine written in C++20, developed as a dissertation project.
 
-It features a physically-based rasterization pipeline, a hardware ray tracing pipeline, cascaded shadow maps, a GPU-accelerated starfield compute pass, GPU-accelerated physics simulation, a hierarchical scene graph with spatial culling, and an integrated ImGui editor.
+It supports three selectable rendering backends — rasterizer, classic ray tracer, and path tracer — all switchable at runtime. It also includes cascaded shadow maps, a GPU-accelerated starfield compute pass, GPU-accelerated physics simulation, a hierarchical scene graph with spatial culling, and an integrated ImGui editor.
 
 ---
 
@@ -18,14 +18,31 @@ It features a physically-based rasterization pipeline, a hardware ray tracing pi
 - Dynamic rendering (no VkRenderPass / VkFramebuffer objects)
 - Vulkan synchronization2 barriers throughout
 
-**Ray tracing pipeline** (VK_KHR_ray_tracing_pipeline + VK_KHR_acceleration_structure)
-- Hardware TLAS/BLAS acceleration structures, rebuilt each frame
-- Raygen → ClosestHit / AnyHit / Miss shader stages
-- Alpha-cutout transparency in AnyHit
-- RT shadow rays for hard shadows
-- Bindless per-model vertex, index, material, and texture arrays
+**Classic ray tracing pipeline** — direct illumination only (VK_KHR_ray_tracing_pipeline + VK_KHR_acceleration_structure)
 
-**Common**
+Traces one primary ray per pixel. On a surface hit, shading is evaluated analytically using PBR (GGX/Smith/Schlick), and a single shadow ray is fired toward the light source to determine occlusion. No indirect bounces are traced — the result is comparable to rasterization with perfect per-pixel shadows, but no global illumination.
+
+- Hardware TLAS/BLAS acceleration structures, rebuilt each frame
+- Alpha-cutout transparency in AnyHit
+- Hard RT shadows via a secondary shadow ray from ClosestHit
+- Bindless per-model vertex, index, material, and texture arrays (bindings 5–8)
+
+**Path tracing pipeline** — full global illumination (same Vulkan RT extension set)
+
+Traces one primary ray per pixel (1 SPP). At each surface hit, a new ray direction is sampled from the BRDF lobe instead of evaluating a light analytically — the process repeats for multiple bounces until a light source is hit or Russian roulette terminates the path. This captures indirect illumination (colour bleeding, inter-reflections) that the classic RT pipeline cannot produce, but at the cost of significant noise at 1 SPP.
+
+- 1 SPP unbiased path tracer with cosine-weighted hemisphere sampling and Russian roulette
+- G-Buffer outputs written by Raygen: world normals (R16G16B16A16), linear depth (R32), motion vectors (R16G16)
+- Temporal reprojection: accumulates history across frames using motion vectors; history is discarded on camera movement to prevent ghosting
+- SVGF-style A-Trous spatial denoiser: 5 wavelet iterations with luminance and normal edge-stopping weights, applied after reprojection
+- Final tonemapped result written back to the RT output image and blitted to the swapchain
+
+**Common to all hardware RT modes**
+- Hardware TLAS/BLAS acceleration structures, rebuilt each frame
+- Raygen → ClosestHit / AnyHit / Miss shader pipeline stages
+- Three-way runtime backend selection via `RenderMode` enum (`Rasterizer`, `RayTracer`, `PathTracer`)
+
+**Common to all modes**
 - Multi-frame buffering (2 frames in flight)
 - Dynamic swapchain resize handling
 - Slang shaders compiled to SPIR-V at build time
@@ -51,7 +68,7 @@ It features a physically-based rasterization pipeline, a hardware ray tracing pi
 - Object selection and transform manipulation
 - Light direction control
 - Physics simulation play / pause
-- Toggle between rasterization and ray tracing at runtime
+- Toggle between rasterizer, classic ray tracer, and path tracer at runtime
 
 ---
 
@@ -75,12 +92,18 @@ Source is organized under `src/` into three areas:
 | `LaphriaEngine.slang` | `vertMain`, `fragMain` | PBR vertex + fragment (CSM lookup, normal mapping, PBR lighting) |
 | `Compute.slang` | `computeMain` | Starfield background — writes to a storage image, blitted to the swapchain |
 | `Shadow.slang` | `shadowVert`, `shadowFrag` | Depth-only CSM pass (4 cascades); alpha-cutout discard in fragment |
-| `Raygen.slang` | `main` | RT camera ray generation — unprojects each pixel into a world-space ray |
-| `ClosestHit.slang` | `main` | RT surface shading — PBR + shadow ray + normal mapping |
-| `AnyHit.slang` | `main` | RT alpha-cutout transparency test |
-| `Miss.slang` | `main` | RT background sky gradient; shadow ray miss → not occluded |
+| `Raygen.slang` | `main` | **Path tracer** — 1 SPP ray generation; writes noisy colour and G-Buffer (normals, depth, motion vectors) |
+| `ClosestHit.slang` | `main` | **Path tracer** — BRDF-sampled bounce; continues the path or returns emissive radiance |
+| `AnyHit.slang` | `main` | **Path tracer** — alpha-cutout transparency test |
+| `Miss.slang` | `main` | **Path tracer** — background sky radiance; shadow ray miss returns unoccluded |
+| `RT_Raygen.slang` | `main` | **Classic RT** — primary ray generation; evaluates direct illumination at the first hit |
+| `RT_ClosestHit.slang` | `main` | **Classic RT** — PBR shading + shadow ray + normal mapping; no indirect bounce |
+| `RT_AnyHit.slang` | `main` | **Classic RT** — alpha-cutout transparency test |
+| `RT_Miss.slang` | `main` | **Classic RT** — background sky gradient; shadow ray miss → not occluded |
+| `Reprojection.slang` | `reprojectionMain` | Temporal reprojection — blends noisy 1 SPP output with history using motion vectors |
+| `Denoiser.slang` | `atrousMain` | A-Trous spatial filter — 5 wavelet iterations; edge-stopping by luminance and surface normals |
 | `Physics.slang` | `physicsMain` | GPU rigid-body integration compute shader |
-| `ShaderCommon.slang` | — | Shared structs (`UniformBuffer`, `ScenePushConstants`, `MaterialData`, `RayPayload`), PBR functions, `mat3Inverse` |
+| `ShaderCommon.slang` | — | Shared structs (`UniformBuffer`, `ScenePushConstants`, `MaterialData`), PBR functions, `mat3Inverse` |
 
 All shaders are compiled from source with `slangc` as part of the CMake build.
 

--- a/src/Core/EngineAuxiliary.h
+++ b/src/Core/EngineAuxiliary.h
@@ -53,6 +53,14 @@ constexpr int      MAX_FRAMES_IN_FLIGHT = 2;
 constexpr uint32_t NUM_SHADOW_CASCADES  = 4;
 constexpr uint32_t SHADOW_MAP_DIM       = 2048;
 
+// Selects which rendering backend is active.
+enum class RenderMode
+{
+	Rasterizer,   // shadow + starfield compute + raster graphics pipeline
+	RayTracer,    // classic RT: direct illumination with RT shadows, tone-mapped in ClosestHit
+	PathTracer,   // path tracer with temporal reprojection and A-Trous denoiser
+};
+
 namespace Laphria
 {
 #ifdef NDEBUG
@@ -106,6 +114,21 @@ struct UniformBufferObject
 	// cascadeSplits: far-plane depth for each cascade in view space (positive, in camera units)
 	alignas(16) glm::vec4 cascadeSplits;
 	alignas(16) glm::mat4 cascadeViewProj[NUM_SHADOW_CASCADES];
+
+	// Path tracer temporal fields
+	alignas(16) glm::mat4 prevViewProj;   // previous frame VP for motion vector reprojection
+	alignas(4)  uint32_t  frameCount;     // monotonically increasing; seeds per-pixel RNG in Raygen
+	alignas(4)  float     jitter_x;       // sub-pixel x jitter in NDC (Halton sequence, zero when TAA disabled)
+	alignas(4)  float     jitter_y;       // sub-pixel y jitter in NDC
+	alignas(4)  uint32_t  _pad0;          // padding for 16-byte struct alignment
+};
+
+struct DenoisePushConstants
+{
+	int32_t stepSize;    // A-Trous step size: 1, 2, 4, 8, 16 for iterations 0-4; unused in reprojection pass
+	int32_t isLastPass;  // 1 on the final A-Trous iteration: triggers tone mapping + history copy
+	float   phiColor;    // luminance edge-stopping weight (typical: 10.0)
+	float   phiNormal;   // normal edge-stopping exponent (typical: 128.0)
 };
 
 struct ScenePushConstants

--- a/src/Core/EngineCore.cpp
+++ b/src/Core/EngineCore.cpp
@@ -66,11 +66,15 @@ void EngineCore::initVulkan()
 	pipelines.createPhysicsPipeline(vulkan);
 	pipelines.createRayTracingPipeline(vulkan);
 	pipelines.createShaderBindingTable(vulkan);
+	pipelines.createDenoiserPipelines(vulkan);
+	pipelines.createClassicRTPipeline(vulkan);
+	pipelines.createClassicRTShaderBindingTable(vulkan);
 
 	createDescriptorSets();
 	createComputeDescriptorSets();
 	createPhysicsDescriptorSets();
 	createRayTracingDescriptorSets();
+	createDenoiserDescriptorSets();
 }
 
 void EngineCore::initImgui()
@@ -130,7 +134,7 @@ void EngineCore::mainLoop()
 
 		ui.draw(window, *scene, *physicsSystem, *resourceManager, *pipelines.descriptorSetLayoutMaterial);
 
-		// If models were loaded during the UI frame, the RT descriptor sets (bindings 2-5:
+		// If models were loaded during the UI frame, the RT descriptor sets (bindings 5-8:
 		// vertex/index/material/texture arrays) must be rebuilt to include the new buffers.
 		// buildBLAS already called queue.waitIdle(), so the queue is idle here.
 		size_t currentModelCount = resourceManager->getModelCount();
@@ -178,11 +182,12 @@ void EngineCore::recreateSwapChain()
 	cleanupSwapChain();
 	swapchain.init(vulkan, window);
 	frames.recreate(vulkan, swapchain);
-	// Compute and RT descriptor sets reference images that are recreated above
-	// (storageImages and rayTracingOutputImages are extent-dependent), so both
-	// must be rewritten after frames.recreate().
+	// Compute, RT, and denoiser descriptor sets reference images that are recreated above
+	// (storageImages, rayTracingOutputImages, and G-Buffer images are extent-dependent),
+	// so all three must be rewritten after frames.recreate().
 	createComputeDescriptorSets();
 	createRayTracingDescriptorSets();
+	createDenoiserDescriptorSets();
 }
 
 void EngineCore::createPhysicsDescriptorSets()
@@ -257,11 +262,11 @@ void EngineCore::createComputeDescriptorSets()
 
 void EngineCore::createRayTracingDescriptorSets()
 {
-	// One set per frame in flight: each set references that frame's TLAS and RT output image.
+	// One set per frame in flight; bindings shifted to accommodate the new G-Buffer images.
+	// RT set bindings: 0 = TLAS, 1 = noisy colour, 2 = normals, 3 = depth, 4 = motion vectors,
+	//                  5 = vertex arrays, 6 = index arrays, 7 = material arrays, 8 = texture array.
 	std::vector<vk::DescriptorSetLayout> layouts(MAX_FRAMES_IN_FLIGHT, *pipelines.rayTracingDescriptorSetLayout);
 
-	// RT set bindings: 0 = TLAS, 1 = output image, 2 = vertex arrays, 3 = index arrays,
-	// 4 = material arrays, 5 = texture array (variably-sized; up to 1000 descriptors per set).
 	std::vector<uint32_t>                                variableDescCounts(MAX_FRAMES_IN_FLIGHT, 1000);
 	vk::DescriptorSetVariableDescriptorCountAllocateInfo variableDescCountInfo{
 	    .descriptorSetCount = MAX_FRAMES_IN_FLIGHT,
@@ -293,22 +298,42 @@ void EngineCore::createRayTracingDescriptorSets()
 		    .descriptorCount = 1,
 		    .descriptorType  = vk::DescriptorType::eAccelerationStructureKHR};
 
-		// Binding 1 — RT output image (written by the raygen shader in General layout).
+		// Binding 1 — noisy colour output (written by the raygen shader in General layout).
 		vk::DescriptorImageInfo rtOutputImageInfo{
 		    .imageView   = *frames.rayTracingOutputImageViews[i],
 		    .imageLayout = vk::ImageLayout::eGeneral};
-
 		vk::WriteDescriptorSet rtOutputWrite{
-		    .dstSet          = *rtDescriptorSets[i],
-		    .dstBinding      = 1,
-		    .dstArrayElement = 0,
-		    .descriptorCount = 1,
-		    .descriptorType  = vk::DescriptorType::eStorageImage,
-		    .pImageInfo      = &rtOutputImageInfo};
+		    .dstSet = *rtDescriptorSets[i], .dstBinding = 1, .dstArrayElement = 0,
+		    .descriptorCount = 1, .descriptorType = vk::DescriptorType::eStorageImage,
+		    .pImageInfo = &rtOutputImageInfo};
+
+		// Binding 2 — G-Buffer world normals.
+		vk::DescriptorImageInfo normalsInfo{.imageView = *frames.rtGBufferNormalsViews[i], .imageLayout = vk::ImageLayout::eGeneral};
+		vk::WriteDescriptorSet normalsWrite{
+		    .dstSet = *rtDescriptorSets[i], .dstBinding = 2, .dstArrayElement = 0,
+		    .descriptorCount = 1, .descriptorType = vk::DescriptorType::eStorageImage,
+		    .pImageInfo = &normalsInfo};
+
+		// Binding 3 — G-Buffer linear depth.
+		vk::DescriptorImageInfo depthInfo{.imageView = *frames.rtGBufferDepthViews[i], .imageLayout = vk::ImageLayout::eGeneral};
+		vk::WriteDescriptorSet depthWrite{
+		    .dstSet = *rtDescriptorSets[i], .dstBinding = 3, .dstArrayElement = 0,
+		    .descriptorCount = 1, .descriptorType = vk::DescriptorType::eStorageImage,
+		    .pImageInfo = &depthInfo};
+
+		// Binding 4 — motion vectors.
+		vk::DescriptorImageInfo mvInfo{.imageView = *frames.rtMotionVectorsViews[i], .imageLayout = vk::ImageLayout::eGeneral};
+		vk::WriteDescriptorSet mvWrite{
+		    .dstSet = *rtDescriptorSets[i], .dstBinding = 4, .dstArrayElement = 0,
+		    .descriptorCount = 1, .descriptorType = vk::DescriptorType::eStorageImage,
+		    .pImageInfo = &mvInfo};
 
 		std::vector<vk::WriteDescriptorSet> descriptorWrites;
 		descriptorWrites.push_back(tlasWrite);
 		descriptorWrites.push_back(rtOutputWrite);
+		descriptorWrites.push_back(normalsWrite);
+		descriptorWrites.push_back(depthWrite);
+		descriptorWrites.push_back(mvWrite);
 
 		// Now we extract ALL global vertices, indices, materials, and textures
 		// across all Scene Nodes that have been uploaded into VRAM by ResourceManager
@@ -355,7 +380,7 @@ void EngineCore::createRayTracingDescriptorSets()
 		{
 			descriptorWrites.push_back(vk::WriteDescriptorSet{
 			    .dstSet          = *rtDescriptorSets[i],
-			    .dstBinding      = 2,
+			    .dstBinding      = 5,
 			    .dstArrayElement = 0,
 			    .descriptorCount = static_cast<uint32_t>(vertexInfos.size()),
 			    .descriptorType  = vk::DescriptorType::eStorageBuffer,
@@ -366,7 +391,7 @@ void EngineCore::createRayTracingDescriptorSets()
 		{
 			descriptorWrites.push_back(vk::WriteDescriptorSet{
 			    .dstSet          = *rtDescriptorSets[i],
-			    .dstBinding      = 3,
+			    .dstBinding      = 6,
 			    .dstArrayElement = 0,
 			    .descriptorCount = static_cast<uint32_t>(indexInfos.size()),
 			    .descriptorType  = vk::DescriptorType::eStorageBuffer,
@@ -377,7 +402,7 @@ void EngineCore::createRayTracingDescriptorSets()
 		{
 			descriptorWrites.push_back(vk::WriteDescriptorSet{
 			    .dstSet          = *rtDescriptorSets[i],
-			    .dstBinding      = 4,
+			    .dstBinding      = 7,
 			    .dstArrayElement = 0,
 			    .descriptorCount = static_cast<uint32_t>(materialInfos.size()),
 			    .descriptorType  = vk::DescriptorType::eStorageBuffer,
@@ -388,7 +413,7 @@ void EngineCore::createRayTracingDescriptorSets()
 		{
 			descriptorWrites.push_back(vk::WriteDescriptorSet{
 			    .dstSet          = *rtDescriptorSets[i],
-			    .dstBinding      = 5,
+			    .dstBinding      = 8,
 			    .dstArrayElement = 0,
 			    .descriptorCount = static_cast<uint32_t>(textureInfos.size()),
 			    .descriptorType  = vk::DescriptorType::eCombinedImageSampler,
@@ -399,17 +424,75 @@ void EngineCore::createRayTracingDescriptorSets()
 	}
 }
 
+void EngineCore::createDenoiserDescriptorSets()
+{
+	// One set per frame in flight. All 13 bindings are storage images.
+	std::vector<vk::DescriptorPoolSize> poolSizes = {
+	    {vk::DescriptorType::eStorageImage, 13 * MAX_FRAMES_IN_FLIGHT}};
+	vk::DescriptorPoolCreateInfo poolInfo{
+	    .flags         = vk::DescriptorPoolCreateFlagBits::eFreeDescriptorSet,
+	    .maxSets       = MAX_FRAMES_IN_FLIGHT,
+	    .poolSizeCount = static_cast<uint32_t>(poolSizes.size()),
+	    .pPoolSizes    = poolSizes.data()};
+	denoiserDescriptorPool = vk::raii::DescriptorPool(vulkan.logicalDevice, poolInfo);
+
+	std::vector<vk::DescriptorSetLayout> layouts(MAX_FRAMES_IN_FLIGHT, *pipelines.denoiserDescriptorSetLayout);
+	vk::DescriptorSetAllocateInfo allocInfo{
+	    .descriptorPool     = *denoiserDescriptorPool,
+	    .descriptorSetCount = static_cast<uint32_t>(layouts.size()),
+	    .pSetLayouts        = layouts.data()};
+	denoiserDescriptorSets.clear();
+	denoiserDescriptorSets = vulkan.logicalDevice.allocateDescriptorSets(allocInfo);
+
+	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
+	{
+		size_t prevSlot = (i + 1) % MAX_FRAMES_IN_FLIGHT;
+
+		// Build the 13 image info structs in binding order.
+		vk::DescriptorImageInfo infos[13] = {
+		    {.imageView = *frames.rayTracingOutputImageViews[i],  .imageLayout = vk::ImageLayout::eGeneral},  // 0: noisy colour
+		    {.imageView = *frames.rtGBufferNormalsViews[i],       .imageLayout = vk::ImageLayout::eGeneral},  // 1: current normals
+		    {.imageView = *frames.rtGBufferDepthViews[i],         .imageLayout = vk::ImageLayout::eGeneral},  // 2: current depth
+		    {.imageView = *frames.rtMotionVectorsViews[i],        .imageLayout = vk::ImageLayout::eGeneral},  // 3: motion vectors
+		    {.imageView = *frames.historyColorViews[prevSlot],    .imageLayout = vk::ImageLayout::eGeneral},  // 4: history colour read
+		    {.imageView = *frames.historyColorViews[i],           .imageLayout = vk::ImageLayout::eGeneral},  // 5: history colour write
+		    {.imageView = *frames.historyMomentsViews[prevSlot],  .imageLayout = vk::ImageLayout::eGeneral},  // 6: history moments read
+		    {.imageView = *frames.historyMomentsViews[i],         .imageLayout = vk::ImageLayout::eGeneral},  // 7: history moments write
+		    {.imageView = *frames.atrousTempViews[0],             .imageLayout = vk::ImageLayout::eGeneral},  // 8: A-Trous buffer A
+		    {.imageView = *frames.atrousTempViews[1],             .imageLayout = vk::ImageLayout::eGeneral},  // 9: A-Trous buffer B
+		    {.imageView = *frames.rayTracingOutputImageViews[i],  .imageLayout = vk::ImageLayout::eGeneral},  // 10: final denoised output (reuses slot 0 image)
+		    {.imageView = *frames.rtGBufferNormalsViews[prevSlot],.imageLayout = vk::ImageLayout::eGeneral},  // 11: previous-frame normals
+		    {.imageView = *frames.rtGBufferDepthViews[prevSlot],  .imageLayout = vk::ImageLayout::eGeneral},  // 12: previous-frame depth
+		};
+
+		std::vector<vk::WriteDescriptorSet> writes;
+		writes.reserve(13);
+		for (uint32_t b = 0; b < 13; ++b)
+		{
+			writes.push_back(vk::WriteDescriptorSet{
+			    .dstSet          = *denoiserDescriptorSets[i],
+			    .dstBinding      = b,
+			    .dstArrayElement = 0,
+			    .descriptorCount = 1,
+			    .descriptorType  = vk::DescriptorType::eStorageImage,
+			    .pImageInfo      = &infos[b]});
+		}
+		vulkan.logicalDevice.updateDescriptorSets(writes, {});
+	}
+}
+
 void EngineCore::recordComputeCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const
 {
-	// 1. Transition Storage Image (frameIndex) to General layout for writing
-	// Barrier waiting for the previous frame's Blit (Transfer Read) to finish before we start Compute Write
+	// 1. Execution Barrier — General Layout for Compute Write
+	// eGeneral→eGeneral: no content discard; waits for the previous frame's TRANSFER_SRC→eGeneral
+	// restore (or the one-time creation pre-transition) before the compute shader writes.
 	transition_image_layout(
 	    *frames.storageImages[frames.frameIndex],
-	    vk::ImageLayout::eUndefined,        // Discard content but wait for execution
 	    vk::ImageLayout::eGeneral,
-	    {},        // srcAccess ignored for Undefined, but we rely on stage dependency
+	    vk::ImageLayout::eGeneral,
+	    {},
 	    vk::AccessFlagBits2::eShaderWrite,
-	    vk::PipelineStageFlagBits2::eTransfer,        // Wait for the previous frame's blit
+	    vk::PipelineStageFlagBits2::eTransfer,        // Wait for the previous frame's restore
 	    vk::PipelineStageFlagBits2::eComputeShader,
 	    vk::ImageAspectFlagBits::eColor);
 
@@ -468,7 +551,121 @@ void EngineCore::recordComputeCommandBuffer(const vk::raii::CommandBuffer &comma
 	                        swapchain.images[imageIndex], vk::ImageLayout::eTransferDstOptimal,
 	                        blitRegion, vk::Filter::eLinear);
 
+	// 3b. Restore storage image to eGeneral so it always matches the layout declared in
+	// computeDescriptorSets. This prevents VUID-vkCmdDraw-None-09600 when the rasterizer's
+	// draw commands follow in the same command buffer.
+	transition_image_layout(
+	    *frames.storageImages[frames.frameIndex],
+	    vk::ImageLayout::eTransferSrcOptimal,
+	    vk::ImageLayout::eGeneral,
+	    vk::AccessFlagBits2::eTransferRead,
+	    {},
+	    vk::PipelineStageFlagBits2::eTransfer,
+	    vk::PipelineStageFlagBits2::eBottomOfPipe,
+	    vk::ImageAspectFlagBits::eColor);
+
 	// 4. Transition SwapChain to Color Attachment for Rendering
+	transition_image_layout(
+	    swapchain.images[imageIndex],
+	    vk::ImageLayout::eTransferDstOptimal,
+	    vk::ImageLayout::eColorAttachmentOptimal,
+	    vk::AccessFlagBits2::eTransferWrite,
+	    vk::AccessFlagBits2::eColorAttachmentWrite | vk::AccessFlagBits2::eColorAttachmentRead,
+	    vk::PipelineStageFlagBits2::eTransfer,
+	    vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+	    vk::ImageAspectFlagBits::eColor);
+}
+
+void EngineCore::recordClassicRTCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const
+{
+	const uint32_t fi = frames.frameIndex;
+
+	// 1. Transition RT Output Image to General Layout for Writing
+	transition_image_layout(
+	    *frames.rayTracingOutputImages[fi],
+	    vk::ImageLayout::eUndefined,
+	    vk::ImageLayout::eGeneral,
+	    {},
+	    vk::AccessFlagBits2::eShaderWrite,
+	    vk::PipelineStageFlagBits2::eTopOfPipe,
+	    vk::PipelineStageFlagBits2::eRayTracingShaderKHR,
+	    vk::ImageAspectFlagBits::eColor);
+
+	// 2. Bind Classic RT Pipeline and Descriptor Sets
+	commandBuffer.bindPipeline(vk::PipelineBindPoint::eRayTracingKHR, *pipelines.classicRTPipeline);
+	commandBuffer.bindDescriptorSets(
+	    vk::PipelineBindPoint::eRayTracingKHR,
+	    *pipelines.rayTracingPipelineLayout,
+	    0,
+	    {*rtDescriptorSets[fi], *descriptorSets[fi]},
+	    nullptr);
+
+	ScenePushConstants pushConstants{};
+	pushConstants.modelMatrix = glm::mat4(1.0f);
+	commandBuffer.pushConstants<ScenePushConstants>(
+	    *pipelines.rayTracingPipelineLayout,
+	    vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eMissKHR,
+	    0,
+	    pushConstants);
+
+	// 3. Dispatch Rays
+	vk::StridedDeviceAddressRegionKHR callableRegion{};
+	commandBuffer.traceRaysKHR(
+	    pipelines.classicRTRaygenRegion,
+	    pipelines.classicRTMissRegion,
+	    pipelines.classicRTHitRegion,
+	    callableRegion,
+	    swapchain.extent.width,
+	    swapchain.extent.height,
+	    1);
+
+	// 4. Transition RT Output Image for Blit (General → TransferSrcOptimal)
+	transition_image_layout(
+	    *frames.rayTracingOutputImages[fi],
+	    vk::ImageLayout::eGeneral,
+	    vk::ImageLayout::eTransferSrcOptimal,
+	    vk::AccessFlagBits2::eShaderWrite,
+	    vk::AccessFlagBits2::eTransferRead,
+	    vk::PipelineStageFlagBits2::eRayTracingShaderKHR,
+	    vk::PipelineStageFlagBits2::eTransfer,
+	    vk::ImageAspectFlagBits::eColor);
+
+	// 5. Transition SwapChain Image for Blit
+	transition_image_layout(
+	    swapchain.images[imageIndex],
+	    vk::ImageLayout::eUndefined,
+	    vk::ImageLayout::eTransferDstOptimal,
+	    {},
+	    vk::AccessFlagBits2::eTransferWrite,
+	    vk::PipelineStageFlagBits2::eTopOfPipe,
+	    vk::PipelineStageFlagBits2::eTransfer,
+	    vk::ImageAspectFlagBits::eColor);
+
+	// 6. Blit RT Output to SwapChain Image
+	vk::ImageBlit blitRegion{
+	    .srcSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1},
+	    .srcOffsets     = {{vk::Offset3D{0, 0, 0}, vk::Offset3D{static_cast<int32_t>(swapchain.extent.width), static_cast<int32_t>(swapchain.extent.height), 1}}},
+	    .dstSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1},
+	    .dstOffsets     = {{vk::Offset3D{0, 0, 0}, vk::Offset3D{static_cast<int32_t>(swapchain.extent.width), static_cast<int32_t>(swapchain.extent.height), 1}}}};
+	commandBuffer.blitImage(
+	    *frames.rayTracingOutputImages[fi], vk::ImageLayout::eTransferSrcOptimal,
+	    swapchain.images[imageIndex],       vk::ImageLayout::eTransferDstOptimal,
+	    blitRegion, vk::Filter::eLinear);
+
+	// 6b. Restore RT output image to eGeneral so it always matches the layout declared in
+	// rtDescriptorSets and denoiserDescriptorSets (prevents VUID-vkCmdDraw-None-09600 if
+	// the render mode is switched back to Rasterizer in a subsequent frame).
+	transition_image_layout(
+	    *frames.rayTracingOutputImages[fi],
+	    vk::ImageLayout::eTransferSrcOptimal,
+	    vk::ImageLayout::eGeneral,
+	    vk::AccessFlagBits2::eTransferRead,
+	    {},
+	    vk::PipelineStageFlagBits2::eTransfer,
+	    vk::PipelineStageFlagBits2::eBottomOfPipe,
+	    vk::ImageAspectFlagBits::eColor);
+
+	// 7. Transition SwapChain to Color Attachment for UI Rendering
 	transition_image_layout(
 	    swapchain.images[imageIndex],
 	    vk::ImageLayout::eTransferDstOptimal,
@@ -482,92 +679,148 @@ void EngineCore::recordComputeCommandBuffer(const vk::raii::CommandBuffer &comma
 
 void EngineCore::recordRayTracingCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const
 {
-	// 1. Transition RT Output Image to General layout for writing
-	transition_image_layout(
-	    *frames.rayTracingOutputImages[frames.frameIndex],
-	    vk::ImageLayout::eUndefined,
-	    vk::ImageLayout::eGeneral,
-	    {},
-	    vk::AccessFlagBits2::eShaderWrite,
-	    vk::PipelineStageFlagBits2::eTopOfPipe,
-	    vk::PipelineStageFlagBits2::eRayTracingShaderKHR,
-	    vk::ImageAspectFlagBits::eColor);
+	const uint32_t fi = frames.frameIndex;
 
-	// 4. Bind Pipeline and Descriptor Sets
+	// 1. Transition All RT Output Images to General Layout for Writing
+	auto transitionToGeneral = [&](vk::Image img) {
+		transition_image_layout(img, vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+		    {}, vk::AccessFlagBits2::eShaderWrite,
+		    vk::PipelineStageFlagBits2::eTopOfPipe, vk::PipelineStageFlagBits2::eRayTracingShaderKHR,
+		    vk::ImageAspectFlagBits::eColor);
+	};
+	transitionToGeneral(*frames.rayTracingOutputImages[fi]);
+	transitionToGeneral(*frames.rtGBufferNormals[fi]);
+	transitionToGeneral(*frames.rtGBufferDepth[fi]);
+	transitionToGeneral(*frames.rtMotionVectors[fi]);
+
+	// 2. Ray Tracing Dispatch (1 SPP Path Tracer)
 	commandBuffer.bindPipeline(vk::PipelineBindPoint::eRayTracingKHR, *pipelines.rayTracingPipeline);
+	commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eRayTracingKHR,
+	    *pipelines.rayTracingPipelineLayout, 0,
+	    {*rtDescriptorSets[fi], *descriptorSets[fi]}, nullptr);
 
-	// Set 0 = RT layout (TLAS, output image, vertex/index/material/texture arrays)
-	// Set 1 = global layout (UBO, CSM shadow maps)
-	commandBuffer.bindDescriptorSets(
-	    vk::PipelineBindPoint::eRayTracingKHR,
-	    *pipelines.rayTracingPipelineLayout,
-	    0,
-	    {*rtDescriptorSets[frames.frameIndex], *descriptorSets[frames.frameIndex]},
-	    nullptr);
-
-	// 5. Push Constants (ScenePushConstants)
-	ScenePushConstants pushConstants{};
-	pushConstants.modelMatrix = glm::mat4(1.0f);        // Default identity
-
-	commandBuffer.pushConstants<ScenePushConstants>(
-	    *pipelines.rayTracingPipelineLayout,
+	ScenePushConstants rtPush{};
+	rtPush.modelMatrix = glm::mat4(1.0f);
+	commandBuffer.pushConstants<ScenePushConstants>(*pipelines.rayTracingPipelineLayout,
 	    vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eMissKHR,
-	    0,
-	    pushConstants);
+	    0, rtPush);
 
-	// 5. Trace Rays Dispatch
 	vk::StridedDeviceAddressRegionKHR callableRegion{};
-	commandBuffer.traceRaysKHR(
-	    pipelines.raygenRegion,
-	    pipelines.missRegion,
-	    pipelines.hitRegion,
-	    callableRegion,
-	    swapchain.extent.width,
-	    swapchain.extent.height,
-	    1);
+	commandBuffer.traceRaysKHR(pipelines.raygenRegion, pipelines.missRegion, pipelines.hitRegion,
+	    callableRegion, swapchain.extent.width, swapchain.extent.height, 1);
 
-	// 6. Transition RT Image for Transfer
-	transition_image_layout(
-	    *frames.rayTracingOutputImages[frames.frameIndex],
-	    vk::ImageLayout::eGeneral,
-	    vk::ImageLayout::eTransferSrcOptimal,
-	    vk::AccessFlagBits2::eShaderWrite,
-	    vk::AccessFlagBits2::eTransferRead,
-	    vk::PipelineStageFlagBits2::eRayTracingShaderKHR,
-	    vk::PipelineStageFlagBits2::eTransfer,
+	// 3. Barrier: RT Writes → Compute Reads
+	auto barrierRTtoCompute = [&](vk::Image img) {
+		transition_image_layout(img, vk::ImageLayout::eGeneral, vk::ImageLayout::eGeneral,
+		    vk::AccessFlagBits2::eShaderWrite, vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite,
+		    vk::PipelineStageFlagBits2::eRayTracingShaderKHR, vk::PipelineStageFlagBits2::eComputeShader,
+		    vk::ImageAspectFlagBits::eColor);
+	};
+	barrierRTtoCompute(*frames.rayTracingOutputImages[fi]);
+	barrierRTtoCompute(*frames.rtGBufferNormals[fi]);
+	barrierRTtoCompute(*frames.rtGBufferDepth[fi]);
+	barrierRTtoCompute(*frames.rtMotionVectors[fi]);
+
+	// Transition the A-Trous ping-pong buffers to General (scratch buffers, discarded each frame).
+	// History images (historyColor/historyMoments) are initialized to General once in
+	// FrameContext::createHistoryResources and stay in General across frames.
+	for (size_t k = 0; k < 2; ++k)
+		transition_image_layout(*frames.atrousTemp[k], vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral,
+		    {}, vk::AccessFlagBits2::eShaderWrite,
+		    vk::PipelineStageFlagBits2::eTopOfPipe, vk::PipelineStageFlagBits2::eComputeShader,
+		    vk::ImageAspectFlagBits::eColor);
+
+	// 4. Reprojection Pass
+	commandBuffer.bindPipeline(vk::PipelineBindPoint::eCompute, *pipelines.reprojectionPipeline);
+	commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute,
+	    *pipelines.denoiserPipelineLayout, 0, *denoiserDescriptorSets[fi], nullptr);
+
+	// phiColor doubles as historyAlpha here: 0.1 when camera is static (90% history),
+	// 1.0 when it moved (discard history to prevent ghosting bands).
+	float                historyAlpha = ptCameraMoved ? 1.0f : 0.1f;
+	DenoisePushConstants reproPush{.stepSize = 0, .isLastPass = 0, .phiColor = historyAlpha, .phiNormal = 128.0f};
+	commandBuffer.pushConstants<DenoisePushConstants>(*pipelines.denoiserPipelineLayout,
+	    vk::ShaderStageFlagBits::eCompute, 0, reproPush);
+
+	const uint32_t gx = (swapchain.extent.width  + 15) / 16;
+	const uint32_t gy = (swapchain.extent.height + 15) / 16;
+	commandBuffer.dispatch(gx, gy, 1);
+
+	// 5. Barrier: Reprojection → A-Trous
+	auto barrierCompute = [&](vk::Image img) {
+		transition_image_layout(img, vk::ImageLayout::eGeneral, vk::ImageLayout::eGeneral,
+		    vk::AccessFlagBits2::eShaderWrite, vk::AccessFlagBits2::eShaderRead | vk::AccessFlagBits2::eShaderWrite,
+		    vk::PipelineStageFlagBits2::eComputeShader, vk::PipelineStageFlagBits2::eComputeShader,
+		    vk::ImageAspectFlagBits::eColor);
+	};
+	barrierCompute(*frames.atrousTemp[0]);
+	barrierCompute(*frames.historyMoments[fi]);   // A-Trous reads historyMomentsOut for variance
+
+	// 6. A-Trous Spatial Filter (5 Iterations)
+	commandBuffer.bindPipeline(vk::PipelineBindPoint::eCompute, *pipelines.atrousPipeline);
+	commandBuffer.bindDescriptorSets(vk::PipelineBindPoint::eCompute,
+	    *pipelines.denoiserPipelineLayout, 0, *denoiserDescriptorSets[fi], nullptr);
+
+	static constexpr int ATROUS_ITERATIONS = 5;
+	for (int iter = 0; iter < ATROUS_ITERATIONS; ++iter)
+	{
+		int32_t stepSize   = 1 << iter;   // 1, 2, 4, 8, 16
+		int32_t isLastPass = (iter == ATROUS_ITERATIONS - 1) ? 1 : 0;
+
+		DenoisePushConstants atrousPush{
+		    .stepSize   = stepSize,
+		    .isLastPass = isLastPass,
+		    .phiColor   = 1.0f,
+		    .phiNormal  = 128.0f};
+		commandBuffer.pushConstants<DenoisePushConstants>(*pipelines.denoiserPipelineLayout,
+		    vk::ShaderStageFlagBits::eCompute, 0, atrousPush);
+		commandBuffer.dispatch(gx, gy, 1);
+
+		if (!isLastPass)
+		{
+			// Barrier between iterations: wait for this pass's write before the next pass reads it.
+			int writeBuf = iter % 2;        // 0→writes[1], 1→writes[0], ...
+			barrierCompute(*frames.atrousTemp[1 - writeBuf]);
+		}
+	}
+
+	// 7. Transition Final Denoised Image for Blit
+	// The last A-Trous pass wrote the tonemapped result to rayTracingOutputImages[fi].
+	transition_image_layout(*frames.rayTracingOutputImages[fi],
+	    vk::ImageLayout::eGeneral, vk::ImageLayout::eTransferSrcOptimal,
+	    vk::AccessFlagBits2::eShaderWrite, vk::AccessFlagBits2::eTransferRead,
+	    vk::PipelineStageFlagBits2::eComputeShader, vk::PipelineStageFlagBits2::eTransfer,
 	    vk::ImageAspectFlagBits::eColor);
 
-	// 7. Transition SwapChain image for Transfer
-	transition_image_layout(
-	    swapchain.images[imageIndex],
-	    vk::ImageLayout::eUndefined,
-	    vk::ImageLayout::eTransferDstOptimal,
-	    {},
-	    vk::AccessFlagBits2::eTransferWrite,
-	    vk::PipelineStageFlagBits2::eTopOfPipe,
-	    vk::PipelineStageFlagBits2::eTransfer,
+	// 8. Transition SwapChain Image for Blit
+	transition_image_layout(swapchain.images[imageIndex],
+	    vk::ImageLayout::eUndefined, vk::ImageLayout::eTransferDstOptimal,
+	    {}, vk::AccessFlagBits2::eTransferWrite,
+	    vk::PipelineStageFlagBits2::eTopOfPipe, vk::PipelineStageFlagBits2::eTransfer,
 	    vk::ImageAspectFlagBits::eColor);
 
-	// 8. Blit RT Output to Swapchain Image
+	// 9. Blit Denoised Result to SwapChain
 	vk::ImageBlit blitRegion{
 	    .srcSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1},
 	    .srcOffsets     = {{vk::Offset3D{0, 0, 0}, vk::Offset3D{static_cast<int32_t>(swapchain.extent.width), static_cast<int32_t>(swapchain.extent.height), 1}}},
 	    .dstSubresource = {vk::ImageAspectFlagBits::eColor, 0, 0, 1},
 	    .dstOffsets     = {{vk::Offset3D{0, 0, 0}, vk::Offset3D{static_cast<int32_t>(swapchain.extent.width), static_cast<int32_t>(swapchain.extent.height), 1}}}};
+	commandBuffer.blitImage(*frames.rayTracingOutputImages[fi], vk::ImageLayout::eTransferSrcOptimal,
+	    swapchain.images[imageIndex], vk::ImageLayout::eTransferDstOptimal, blitRegion, vk::Filter::eLinear);
 
-	commandBuffer.blitImage(*frames.rayTracingOutputImages[frames.frameIndex], vk::ImageLayout::eTransferSrcOptimal,
-	                        swapchain.images[imageIndex], vk::ImageLayout::eTransferDstOptimal,
-	                        blitRegion, vk::Filter::eLinear);
+	// 9b. Restore RT Output Image to eGeneral so It Matches rtDescriptorSets / denoiserDescriptorSets
+	// (prevents VUID-vkCmdDraw-None-09600 when switching back to Rasterizer mode).
+	transition_image_layout(*frames.rayTracingOutputImages[fi],
+	    vk::ImageLayout::eTransferSrcOptimal, vk::ImageLayout::eGeneral,
+	    vk::AccessFlagBits2::eTransferRead, {},
+	    vk::PipelineStageFlagBits2::eTransfer, vk::PipelineStageFlagBits2::eBottomOfPipe,
+	    vk::ImageAspectFlagBits::eColor);
 
-	// 9. Transition SwapChain to Color Attachment for UI Rendering
-	transition_image_layout(
-	    swapchain.images[imageIndex],
-	    vk::ImageLayout::eTransferDstOptimal,
-	    vk::ImageLayout::eColorAttachmentOptimal,
-	    vk::AccessFlagBits2::eTransferWrite,
-	    vk::AccessFlagBits2::eColorAttachmentWrite | vk::AccessFlagBits2::eColorAttachmentRead,
-	    vk::PipelineStageFlagBits2::eTransfer,
-	    vk::PipelineStageFlagBits2::eColorAttachmentOutput,
+	// 10. Transition SwapChain to Color Attachment for UI Rendering
+	transition_image_layout(swapchain.images[imageIndex],
+	    vk::ImageLayout::eTransferDstOptimal, vk::ImageLayout::eColorAttachmentOptimal,
+	    vk::AccessFlagBits2::eTransferWrite, vk::AccessFlagBits2::eColorAttachmentWrite | vk::AccessFlagBits2::eColorAttachmentRead,
+	    vk::PipelineStageFlagBits2::eTransfer, vk::PipelineStageFlagBits2::eColorAttachmentOutput,
 	    vk::ImageAspectFlagBits::eColor);
 }
 
@@ -725,7 +978,7 @@ void EngineCore::recordCommandBuffer(uint32_t imageIndex) const
 		}
 	}
 
-	if (ui.useRayTracing)
+	if (ui.renderMode != RenderMode::Rasterizer)
 	{
 		// Only copy instance data when there is something to copy; building with
 		// primitiveCount = 0 is valid and produces a traversable empty TLAS.
@@ -789,8 +1042,8 @@ void EngineCore::recordCommandBuffer(uint32_t imageIndex) const
 	// --- End TLAS Build ---
 
 	// ── Cascaded Shadow Map Pass ──────────────────────────────────────────────
-	// Only run for the raster path; the RT pipeline handles its own shadowing.
-	if (!ui.useRayTracing)
+	// Only run for the raster path; both RT pipelines handle their own shadowing.
+	if (ui.renderMode == RenderMode::Rasterizer)
 	{
 		vk::Image shadowImg = *frames.shadowImages[frames.frameIndex];
 
@@ -904,10 +1157,13 @@ void EngineCore::recordCommandBuffer(uint32_t imageIndex) const
 		recordComputeCommandBuffer(commandBuffer, imageIndex);
 	}
 
-	if (ui.useRayTracing)
+	if (ui.renderMode == RenderMode::PathTracer)
 	{
-		// Run Ray Tracing Pipeline
 		recordRayTracingCommandBuffer(commandBuffer, imageIndex);
+	}
+	else if (ui.renderMode == RenderMode::RayTracer)
+	{
+		recordClassicRTCommandBuffer(commandBuffer, imageIndex);
 	}
 
 	transition_image_layout(
@@ -943,7 +1199,7 @@ void EngineCore::recordCommandBuffer(uint32_t imageIndex) const
 
 	commandBuffer.beginRendering(renderingInfo);
 
-	if (!ui.useRayTracing)
+	if (ui.renderMode == RenderMode::Rasterizer)
 	{
 		commandBuffer.bindPipeline(vk::PipelineBindPoint::eGraphics, *pipelines.graphicsPipeline);
 
@@ -1046,6 +1302,15 @@ void EngineCore::drawFrame()
 		throw std::runtime_error("failed to acquire swap chain image!");
 	}
 	frames.updateUniformBuffer(frames.frameIndex, camera, swapchain.extent, ui.lightDirection);
+
+	// Detect camera movement for path tracer history reset.
+	// Any translation or rotation invalidates the reprojected history.
+	ptCameraMoved = (glm::distance(camera.position, ptPrevCameraPos) > 1e-5f ||
+	                 std::abs(camera.pitch - ptPrevPitch)             > 1e-5f ||
+	                 std::abs(camera.yaw   - ptPrevYaw)               > 1e-5f);
+	ptPrevCameraPos = camera.position;
+	ptPrevPitch     = camera.pitch;
+	ptPrevYaw       = camera.yaw;
 
 	// Only reset the fence if we are submitting work
 	vulkan.logicalDevice.resetFences(*frames.inFlightFences[frames.frameIndex]);

--- a/src/Core/EngineCore.h
+++ b/src/Core/EngineCore.h
@@ -55,10 +55,20 @@ class EngineCore
 	// Ray Tracing Resources
 	std::vector<vk::raii::DescriptorSet> rtDescriptorSets;
 
+	// Denoiser Resources (one set per frame in flight)
+	vk::raii::DescriptorPool             denoiserDescriptorPool{nullptr};
+	std::vector<vk::raii::DescriptorSet> denoiserDescriptorSets;
+
 	// Scene System
 	std::unique_ptr<Scene>           scene;
 	std::unique_ptr<ResourceManager> resourceManager;
 	std::unique_ptr<PhysicsSystem>   physicsSystem;
+
+	// Path tracer camera movement detection (history reset on camera change)
+	glm::vec3 ptPrevCameraPos{0.f};
+	float     ptPrevPitch{0.f};
+	float     ptPrevYaw{0.f};
+	bool      ptCameraMoved{false};
 
 	void initWindow();
 
@@ -81,8 +91,10 @@ class EngineCore
 	void createComputeDescriptorSets();
 
 	void createRayTracingDescriptorSets();
+	void createDenoiserDescriptorSets();
 
 	void recordComputeCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const;
+	void recordClassicRTCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const;
 	void recordRayTracingCommandBuffer(const vk::raii::CommandBuffer &commandBuffer, uint32_t imageIndex) const;
 
 	void createDescriptorPool();

--- a/src/Core/FrameContext.cpp
+++ b/src/Core/FrameContext.cpp
@@ -17,6 +17,9 @@ void FrameContext::init(VulkanDevice &dev, SwapchainManager &swapchain)
 	createDepthResources(dev, swapchain);
 	createStorageResources(dev, swapchain);
 	createRayTracingOutputImages(dev, swapchain);
+	createGBufferResources(dev, swapchain);
+	createHistoryResources(dev, swapchain);
+	createAtrousResources(dev, swapchain);
 	// Shadow resources are extent-independent and live for the engine's full lifetime.
 	createShadowResources(dev);
 
@@ -36,6 +39,28 @@ void FrameContext::cleanupSwapChainDependents()
 	depthImageViews.clear();
 	depthImages.clear();
 	depthImagesMemory.clear();
+
+	// G-Buffer images are extent-dependent.
+	rtGBufferNormalsViews.clear();
+	rtGBufferNormals.clear();
+	rtGBufferNormalsMemory.clear();
+	rtGBufferDepthViews.clear();
+	rtGBufferDepth.clear();
+	rtGBufferDepthMemory.clear();
+	rtMotionVectorsViews.clear();
+	rtMotionVectors.clear();
+	rtMotionVectorsMemory.clear();
+
+	// History and A-Trous images are extent-dependent.
+	historyColorViews.clear();
+	historyColor.clear();
+	historyColorMemory.clear();
+	historyMomentsViews.clear();
+	historyMoments.clear();
+	historyMomentsMemory.clear();
+	atrousTempViews.clear();
+	atrousTemp.clear();
+	atrousTempMemory.clear();
 }
 
 void FrameContext::recreate(VulkanDevice &dev, SwapchainManager &swapchain)
@@ -44,6 +69,9 @@ void FrameContext::recreate(VulkanDevice &dev, SwapchainManager &swapchain)
 	createStorageResources(dev, swapchain);
 	createRayTracingOutputImages(dev, swapchain);
 	createDepthResources(dev, swapchain);
+	createGBufferResources(dev, swapchain);
+	createHistoryResources(dev, swapchain);
+	createAtrousResources(dev, swapchain);
 }
 
 void FrameContext::createCommandPool(VulkanDevice &dev)
@@ -145,6 +173,16 @@ void FrameContext::createStorageResources(VulkanDevice &dev, SwapchainManager &s
 		                                                         vk::Format::eR16G16B16A16Sfloat,
 		                                                         vk::ImageAspectFlagBits::eColor));
 	}
+
+	// Pre-transition all storage images to eGeneral so they always match the layout declared
+	// in computeDescriptorSets, even on frames where the compute pass hasn't run yet.
+	{
+		auto cmd = VulkanUtils::beginSingleTimeCommands(dev.logicalDevice, commandPool);
+		for (auto &img : storageImages)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		VulkanUtils::endSingleTimeCommands(dev.logicalDevice, dev.queue, commandPool, cmd);
+	}
 }
 
 void FrameContext::createRayTracingOutputImages(VulkanDevice &dev, SwapchainManager &swapchain)
@@ -176,6 +214,16 @@ void FrameContext::createRayTracingOutputImages(VulkanDevice &dev, SwapchainMana
 		                                                                  vk::Format::eR16G16B16A16Sfloat,
 		                                                                  vk::ImageAspectFlagBits::eColor));
 	}
+
+	// Pre-transition to eGeneral so the layout always matches rtDescriptorSets / denoiserDescriptorSets
+	// even when the path tracer or classic RT hasn't rendered yet (e.g. on the first rasterizer frame).
+	{
+		auto cmd = VulkanUtils::beginSingleTimeCommands(dev.logicalDevice, commandPool);
+		for (auto &img : rayTracingOutputImages)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		VulkanUtils::endSingleTimeCommands(dev.logicalDevice, dev.queue, commandPool, cmd);
+	}
 }
 
 void FrameContext::createUniformBuffers(VulkanDevice &dev)
@@ -201,7 +249,7 @@ void FrameContext::createUniformBuffers(VulkanDevice &dev)
 	}
 }
 
-void FrameContext::updateUniformBuffer(uint32_t frameIdx, const Camera &camera, vk::Extent2D extent, glm::vec3 lightDirection) const
+void FrameContext::updateUniformBuffer(uint32_t frameIdx, const Camera &camera, vk::Extent2D extent, glm::vec3 lightDirection)
 {
 	Laphria::UniformBufferObject ubo{};
 	ubo.view = camera.getViewMatrix();
@@ -317,6 +365,17 @@ void FrameContext::updateUniformBuffer(uint32_t frameIdx, const Camera &camera, 
 		ubo.cascadeViewProj[i] = lightProj * lightView;
 	}
 
+	// Path tracer temporal fields — carry the previous frame's VP and advance the frame counter.
+	ubo.prevViewProj = prevViewProj;
+	ubo.frameCount   = frameCount;
+	ubo.jitter_x     = 0.0f;   // Sub-pixel jitter disabled; set to halton values to enable TAA
+	ubo.jitter_y     = 0.0f;
+	ubo._pad0        = 0;
+
+	// Update persistent state for the next frame.
+	prevViewProj = ubo.proj * ubo.view;
+	++frameCount;
+
 	memcpy(uniformBuffersMapped[frameIdx], &ubo, sizeof(ubo));
 }
 
@@ -387,6 +446,184 @@ void FrameContext::createShadowResources(VulkanDevice &dev)
 	    .borderColor             = vk::BorderColor::eFloatOpaqueWhite,
 	    .unnormalizedCoordinates = vk::False};
 	shadowSampler = vk::raii::Sampler(dev.logicalDevice, samplerInfo);
+}
+
+void FrameContext::createGBufferResources(VulkanDevice &dev, SwapchainManager &swapchain)
+{
+	rtGBufferNormals.clear();      rtGBufferNormalsMemory.clear();      rtGBufferNormalsViews.clear();
+	rtGBufferDepth.clear();        rtGBufferDepthMemory.clear();        rtGBufferDepthViews.clear();
+	rtMotionVectors.clear();       rtMotionVectorsMemory.clear();       rtMotionVectorsViews.clear();
+
+	rtGBufferNormals.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtGBufferNormalsMemory.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtGBufferNormalsViews.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtGBufferDepth.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtGBufferDepthMemory.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtGBufferDepthViews.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtMotionVectors.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtMotionVectorsMemory.reserve(MAX_FRAMES_IN_FLIGHT);
+	rtMotionVectorsViews.reserve(MAX_FRAMES_IN_FLIGHT);
+
+	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
+	{
+		// Normals — R16G16B16A16_SFLOAT: world-space XYZ packed into RGB, W unused.
+		{
+			vk::raii::Image        img{nullptr};
+			vk::raii::DeviceMemory mem{nullptr};
+			VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+			                         swapchain.extent.width, swapchain.extent.height,
+			                         vk::Format::eR16G16B16A16Sfloat, vk::ImageTiling::eOptimal,
+			                         vk::ImageUsageFlagBits::eStorage,
+			                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+			rtGBufferNormals.push_back(std::move(img));
+			rtGBufferNormalsMemory.push_back(std::move(mem));
+			rtGBufferNormalsViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+			    *rtGBufferNormals.back(), vk::Format::eR16G16B16A16Sfloat, vk::ImageAspectFlagBits::eColor));
+		}
+
+		// Depth — R32_SFLOAT: linear ray hit distance (negative = sky miss).
+		{
+			vk::raii::Image        img{nullptr};
+			vk::raii::DeviceMemory mem{nullptr};
+			VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+			                         swapchain.extent.width, swapchain.extent.height,
+			                         vk::Format::eR32Sfloat, vk::ImageTiling::eOptimal,
+			                         vk::ImageUsageFlagBits::eStorage,
+			                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+			rtGBufferDepth.push_back(std::move(img));
+			rtGBufferDepthMemory.push_back(std::move(mem));
+			rtGBufferDepthViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+			    *rtGBufferDepth.back(), vk::Format::eR32Sfloat, vk::ImageAspectFlagBits::eColor));
+		}
+
+		// Motion vectors — R16G16_SFLOAT: screen-space pixel offset in UV space.
+		{
+			vk::raii::Image        img{nullptr};
+			vk::raii::DeviceMemory mem{nullptr};
+			VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+			                         swapchain.extent.width, swapchain.extent.height,
+			                         vk::Format::eR16G16Sfloat, vk::ImageTiling::eOptimal,
+			                         vk::ImageUsageFlagBits::eStorage,
+			                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+			rtMotionVectors.push_back(std::move(img));
+			rtMotionVectorsMemory.push_back(std::move(mem));
+			rtMotionVectorsViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+			    *rtMotionVectors.back(), vk::Format::eR16G16Sfloat, vk::ImageAspectFlagBits::eColor));
+		}
+	}
+
+	// Pre-transition all G-Buffer images to eGeneral so they match the declared layout in
+	// rtDescriptorSets and denoiserDescriptorSets, even when no RT pass has run yet.
+	{
+		auto cmd = VulkanUtils::beginSingleTimeCommands(dev.logicalDevice, commandPool);
+		for (auto &img : rtGBufferNormals)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		for (auto &img : rtGBufferDepth)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		for (auto &img : rtMotionVectors)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		VulkanUtils::endSingleTimeCommands(dev.logicalDevice, dev.queue, commandPool, cmd);
+	}
+}
+
+void FrameContext::createHistoryResources(VulkanDevice &dev, SwapchainManager &swapchain)
+{
+	historyColor.clear();   historyColorMemory.clear();   historyColorViews.clear();
+	historyMoments.clear(); historyMomentsMemory.clear(); historyMomentsViews.clear();
+
+	historyColor.reserve(MAX_FRAMES_IN_FLIGHT);
+	historyColorMemory.reserve(MAX_FRAMES_IN_FLIGHT);
+	historyColorViews.reserve(MAX_FRAMES_IN_FLIGHT);
+	historyMoments.reserve(MAX_FRAMES_IN_FLIGHT);
+	historyMomentsMemory.reserve(MAX_FRAMES_IN_FLIGHT);
+	historyMomentsViews.reserve(MAX_FRAMES_IN_FLIGHT);
+
+	for (size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; i++)
+	{
+		// Accumulated color history — R16G16B16A16_SFLOAT; written by reprojection, read next frame.
+		{
+			vk::raii::Image        img{nullptr};
+			vk::raii::DeviceMemory mem{nullptr};
+			VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+			                         swapchain.extent.width, swapchain.extent.height,
+			                         vk::Format::eR16G16B16A16Sfloat, vk::ImageTiling::eOptimal,
+			                         vk::ImageUsageFlagBits::eStorage,
+			                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+			historyColor.push_back(std::move(img));
+			historyColorMemory.push_back(std::move(mem));
+			historyColorViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+			    *historyColor.back(), vk::Format::eR16G16B16A16Sfloat, vk::ImageAspectFlagBits::eColor));
+		}
+
+		// Moments — R16G16_SFLOAT: R = first moment (mean luminance), G = second moment (mean lum²).
+		{
+			vk::raii::Image        img{nullptr};
+			vk::raii::DeviceMemory mem{nullptr};
+			VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+			                         swapchain.extent.width, swapchain.extent.height,
+			                         vk::Format::eR16G16Sfloat, vk::ImageTiling::eOptimal,
+			                         vk::ImageUsageFlagBits::eStorage,
+			                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+			historyMoments.push_back(std::move(img));
+			historyMomentsMemory.push_back(std::move(mem));
+			historyMomentsViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+			    *historyMoments.back(), vk::Format::eR16G16Sfloat, vk::ImageAspectFlagBits::eColor));
+		}
+	}
+
+	// Transition all history images from UNDEFINED to GENERAL once so the layout matches
+	// the eGeneral written in the denoiser descriptor set on the first frame (and after any
+	// swapchain resize that recreates these images).  atrousTemp gets the same treatment
+	// inside recordRayTracingCommandBuffer each frame, but history images must NOT be
+	// discarded frame-to-frame, so a one-time init here is the correct approach.
+	{
+		auto cmd = VulkanUtils::beginSingleTimeCommands(dev.logicalDevice, commandPool);
+		for (auto &img : historyColor)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		for (auto &img : historyMoments)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		VulkanUtils::endSingleTimeCommands(dev.logicalDevice, dev.queue, commandPool, cmd);
+	}
+}
+
+void FrameContext::createAtrousResources(VulkanDevice &dev, SwapchainManager &swapchain)
+{
+	atrousTemp.clear();   atrousTempMemory.clear();   atrousTempViews.clear();
+	atrousTemp.reserve(2);
+	atrousTempMemory.reserve(2);
+	atrousTempViews.reserve(2);
+
+	// Two ping-pong buffers — shared across frame slots since only one frame runs the denoiser at a time.
+	// Reprojection writes its output to atrousTemp[0]; A-Trous iterations alternate between [0] and [1].
+	for (size_t i = 0; i < 2; i++)
+	{
+		vk::raii::Image        img{nullptr};
+		vk::raii::DeviceMemory mem{nullptr};
+		VulkanUtils::createImage(dev.logicalDevice, dev.physicalDevice,
+		                         swapchain.extent.width, swapchain.extent.height,
+		                         vk::Format::eR16G16B16A16Sfloat, vk::ImageTiling::eOptimal,
+		                         vk::ImageUsageFlagBits::eStorage,
+		                         vk::MemoryPropertyFlagBits::eDeviceLocal, img, mem);
+		atrousTemp.push_back(std::move(img));
+		atrousTempMemory.push_back(std::move(mem));
+		atrousTempViews.push_back(VulkanUtils::createImageView(dev.logicalDevice,
+		    *atrousTemp.back(), vk::Format::eR16G16B16A16Sfloat, vk::ImageAspectFlagBits::eColor));
+	}
+
+	// Pre-transition A-Trous ping-pong buffers to eGeneral so they match the declared layout in
+	// denoiserDescriptorSets, even when no path tracer denoiser pass has run yet.
+	{
+		auto cmd = VulkanUtils::beginSingleTimeCommands(dev.logicalDevice, commandPool);
+		for (auto &img : atrousTemp)
+			VulkanUtils::recordImageLayoutTransition(cmd, *img,
+			    vk::ImageLayout::eUndefined, vk::ImageLayout::eGeneral);
+		VulkanUtils::endSingleTimeCommands(dev.logicalDevice, dev.queue, commandPool, cmd);
+	}
 }
 
 void FrameContext::createTLASResources(VulkanDevice &dev)

--- a/src/Core/FrameContext.h
+++ b/src/Core/FrameContext.h
@@ -18,7 +18,7 @@ class FrameContext
 	void init(VulkanDevice &dev, SwapchainManager &swapchain);
 	void cleanupSwapChainDependents();
 	void recreate(VulkanDevice &dev, SwapchainManager &swapchain);
-	void updateUniformBuffer(uint32_t frameIdx, const Camera &camera, vk::Extent2D extent, glm::vec3 lightDirection) const;
+	void updateUniformBuffer(uint32_t frameIdx, const Camera &camera, vk::Extent2D extent, glm::vec3 lightDirection);
 
 	// ── CSM Shadow resources (extent-independent, NOT cleaned on swapchain resize) ──
 	// One depth array image per frame-in-flight; each has NUM_SHADOW_CASCADES layers at SHADOW_MAP_DIM x SHADOW_MAP_DIM.
@@ -54,11 +54,46 @@ class FrameContext
 	std::vector<vk::raii::ImageView>    storageImageViews;
 
 	// ── RT output images (per frame in flight) ────────────────────────────
-	// Separate from the compute storage images: the RT pipeline writes here,
-	// then these are blitted to the swapchain independently of the starfield.
+	// Noisy 1-SPP path tracer output. After denoising, the final denoised result is
+	// written back here so the existing swapchain blit path remains unchanged.
 	std::vector<vk::raii::Image>        rayTracingOutputImages;
 	std::vector<vk::raii::DeviceMemory> rayTracingOutputImagesMemory;
 	std::vector<vk::raii::ImageView>    rayTracingOutputImageViews;
+
+	// ── G-Buffer images written by the Raygen shader (per frame in flight) ──
+	// All are swapchain-extent-dependent and recreated on resize.
+	std::vector<vk::raii::Image>        rtGBufferNormals;        // R16G16B16A16_SFLOAT world normals
+	std::vector<vk::raii::DeviceMemory> rtGBufferNormalsMemory;
+	std::vector<vk::raii::ImageView>    rtGBufferNormalsViews;
+
+	std::vector<vk::raii::Image>        rtGBufferDepth;          // R32_SFLOAT linear depth (ray hit t)
+	std::vector<vk::raii::DeviceMemory> rtGBufferDepthMemory;
+	std::vector<vk::raii::ImageView>    rtGBufferDepthViews;
+
+	std::vector<vk::raii::Image>        rtMotionVectors;         // R16G16_SFLOAT screen-space motion
+	std::vector<vk::raii::DeviceMemory> rtMotionVectorsMemory;
+	std::vector<vk::raii::ImageView>    rtMotionVectorsViews;
+
+	// ── Temporal accumulation history buffers (per frame in flight) ─────────
+	// historyColor[i] stores the blended reprojection output from frame slot i,
+	// read by frame slot (i+1)%2 as "previous frame" and written by frame slot i.
+	std::vector<vk::raii::Image>        historyColor;            // R16G16B16A16_SFLOAT
+	std::vector<vk::raii::DeviceMemory> historyColorMemory;
+	std::vector<vk::raii::ImageView>    historyColorViews;
+
+	std::vector<vk::raii::Image>        historyMoments;          // R16G16_SFLOAT (mean, variance)
+	std::vector<vk::raii::DeviceMemory> historyMomentsMemory;
+	std::vector<vk::raii::ImageView>    historyMomentsViews;
+
+	// ── A-Trous ping-pong buffers (2, shared across frames — not per-slot) ──
+	// atrousTemp[0] receives the reprojection output; iterations alternate between [0] and [1].
+	std::vector<vk::raii::Image>        atrousTemp;              // 2 × R16G16B16A16_SFLOAT
+	std::vector<vk::raii::DeviceMemory> atrousTempMemory;
+	std::vector<vk::raii::ImageView>    atrousTempViews;
+
+	// ── Temporal tracking (updated each frame by updateUniformBuffer) ────────
+	glm::mat4 prevViewProj{1.0f};   // VP matrix of the last submitted frame
+	uint32_t  frameCount = 0;       // monotonically increasing, seeds per-pixel RNG
 
 	// ── Uniform buffers (per frame in flight) ─────────────────────────────
 	std::vector<vk::raii::Buffer>       uniformBuffers;
@@ -87,6 +122,9 @@ class FrameContext
 	void createDepthResources(VulkanDevice &dev, SwapchainManager &swapchain);
 	void createStorageResources(VulkanDevice &dev, SwapchainManager &swapchain);
 	void createRayTracingOutputImages(VulkanDevice &dev, SwapchainManager &swapchain);
+	void createGBufferResources(VulkanDevice &dev, SwapchainManager &swapchain);
+	void createHistoryResources(VulkanDevice &dev, SwapchainManager &swapchain);
+	void createAtrousResources(VulkanDevice &dev, SwapchainManager &swapchain);
 
 	void createUniformBuffers(VulkanDevice &dev);
 	void createTLASResources(VulkanDevice &dev);

--- a/src/Core/PipelineCollection.cpp
+++ b/src/Core/PipelineCollection.cpp
@@ -19,6 +19,7 @@ void PipelineCollection::createDescriptorSetLayouts(VulkanDevice &dev)
 	createComputeDescriptorSetLayout(dev);
 	createRayTracingDescriptorSetLayout(dev);
 	createPhysicsDescriptorSetLayout(dev);
+	createDenoiserDescriptorSetLayout(dev);
 }
 
 // ── Descriptor Set Layout Implementations ──────────────────────────────────
@@ -120,44 +121,65 @@ void PipelineCollection::createPhysicsDescriptorSetLayout(VulkanDevice &dev)
 
 void PipelineCollection::createRayTracingDescriptorSetLayout(VulkanDevice &dev)
 {
-	std::array<vk::DescriptorSetLayoutBinding, 6> bindings = {
-	    vk::DescriptorSetLayoutBinding{// TLAS
+	// Set 0 — RT pipeline bindings.
+	// Bindings 0-4: acceleration structure + storage images written by Raygen.
+	// Bindings 5-8: mesh data arrays read by ClosestHit (shifted from old 2-5 to make room).
+	std::array<vk::DescriptorSetLayoutBinding, 9> bindings = {
+	    vk::DescriptorSetLayoutBinding{// 0: TLAS
 	                                   .binding         = 0,
 	                                   .descriptorType  = vk::DescriptorType::eAccelerationStructureKHR,
 	                                   .descriptorCount = 1,
 	                                   .stageFlags      = vk::ShaderStageFlagBits::eRaygenKHR | vk::ShaderStageFlagBits::eClosestHitKHR},
-	    vk::DescriptorSetLayoutBinding{// Output Image
+	    vk::DescriptorSetLayoutBinding{// 1: Noisy colour output (1 SPP path tracer)
 	                                   .binding         = 1,
 	                                   .descriptorType  = vk::DescriptorType::eStorageImage,
 	                                   .descriptorCount = 1,
 	                                   .stageFlags      = vk::ShaderStageFlagBits::eRaygenKHR},
-	    vk::DescriptorSetLayoutBinding{// Vertex Buffers Array
+	    vk::DescriptorSetLayoutBinding{// 2: G-Buffer world normals
 	                                   .binding         = 2,
-	                                   .descriptorType  = vk::DescriptorType::eStorageBuffer,
-	                                   .descriptorCount = 1000,
-	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR},
-	    vk::DescriptorSetLayoutBinding{// Index Buffers Array
+	                                   .descriptorType  = vk::DescriptorType::eStorageImage,
+	                                   .descriptorCount = 1,
+	                                   .stageFlags      = vk::ShaderStageFlagBits::eRaygenKHR},
+	    vk::DescriptorSetLayoutBinding{// 3: G-Buffer linear depth (ray hit t)
 	                                   .binding         = 3,
-	                                   .descriptorType  = vk::DescriptorType::eStorageBuffer,
-	                                   .descriptorCount = 1000,
-	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR},
-	    vk::DescriptorSetLayoutBinding{// Material Buffers Array
+	                                   .descriptorType  = vk::DescriptorType::eStorageImage,
+	                                   .descriptorCount = 1,
+	                                   .stageFlags      = vk::ShaderStageFlagBits::eRaygenKHR},
+	    vk::DescriptorSetLayoutBinding{// 4: Motion vectors
 	                                   .binding         = 4,
+	                                   .descriptorType  = vk::DescriptorType::eStorageImage,
+	                                   .descriptorCount = 1,
+	                                   .stageFlags      = vk::ShaderStageFlagBits::eRaygenKHR},
+	    vk::DescriptorSetLayoutBinding{// 5: Vertex buffers array
+	                                   .binding         = 5,
 	                                   .descriptorType  = vk::DescriptorType::eStorageBuffer,
 	                                   .descriptorCount = 1000,
 	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR},
-	    vk::DescriptorSetLayoutBinding{// Textures Array
-	                                   .binding         = 5,
+	    vk::DescriptorSetLayoutBinding{// 6: Index buffers array
+	                                   .binding         = 6,
+	                                   .descriptorType  = vk::DescriptorType::eStorageBuffer,
+	                                   .descriptorCount = 1000,
+	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR},
+	    vk::DescriptorSetLayoutBinding{// 7: Material buffers array
+	                                   .binding         = 7,
+	                                   .descriptorType  = vk::DescriptorType::eStorageBuffer,
+	                                   .descriptorCount = 1000,
+	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR},
+	    vk::DescriptorSetLayoutBinding{// 8: Textures array — variably sized
+	                                   .binding         = 8,
 	                                   .descriptorType  = vk::DescriptorType::eCombinedImageSampler,
 	                                   .descriptorCount = 1000,
 	                                   .stageFlags      = vk::ShaderStageFlagBits::eClosestHitKHR | vk::ShaderStageFlagBits::eAnyHitKHR}};
-	std::array<vk::DescriptorBindingFlags, 6> flags = {
-	    vk::DescriptorBindingFlags{},
-	    vk::DescriptorBindingFlags{},
-	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,
-	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,
-	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,
-	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eVariableDescriptorCount | vk::DescriptorBindingFlagBits::eUpdateAfterBind};
+	std::array<vk::DescriptorBindingFlags, 9> flags = {
+	    vk::DescriptorBindingFlags{},   // 0: TLAS
+	    vk::DescriptorBindingFlags{},   // 1: noisy colour
+	    vk::DescriptorBindingFlags{},   // 2: normals
+	    vk::DescriptorBindingFlags{},   // 3: depth
+	    vk::DescriptorBindingFlags{},   // 4: motion vectors
+	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,  // 5
+	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,  // 6
+	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eUpdateAfterBind,  // 7
+	    vk::DescriptorBindingFlagBits::ePartiallyBound | vk::DescriptorBindingFlagBits::eVariableDescriptorCount | vk::DescriptorBindingFlagBits::eUpdateAfterBind}; // 8
 	vk::DescriptorSetLayoutBindingFlagsCreateInfo bindingFlags{
 	    .bindingCount  = static_cast<uint32_t>(flags.size()),
 	    .pBindingFlags = flags.data()};
@@ -167,6 +189,31 @@ void PipelineCollection::createRayTracingDescriptorSetLayout(VulkanDevice &dev)
 	    .bindingCount = static_cast<uint32_t>(bindings.size()),
 	    .pBindings    = bindings.data()};
 	rayTracingDescriptorSetLayout = vk::raii::DescriptorSetLayout(dev.logicalDevice, layoutInfo);
+}
+
+void PipelineCollection::createDenoiserDescriptorSetLayout(VulkanDevice &dev)
+{
+	// 13 storage image bindings covering all denoiser pass inputs and outputs.
+	// Both reprojection and A-Trous shaders share this single layout, selecting
+	// the relevant bindings via the shader source.
+	std::array<vk::DescriptorSetLayoutBinding, 13> bindings = {
+	    vk::DescriptorSetLayoutBinding{.binding = 0,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // noisy colour (reprojection input)
+	    vk::DescriptorSetLayoutBinding{.binding = 1,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // G-Buffer normals (current frame)
+	    vk::DescriptorSetLayoutBinding{.binding = 2,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // G-Buffer depth (current frame)
+	    vk::DescriptorSetLayoutBinding{.binding = 3,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // motion vectors
+	    vk::DescriptorSetLayoutBinding{.binding = 4,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // history colour read  [(i+1)%2]
+	    vk::DescriptorSetLayoutBinding{.binding = 5,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // history colour write [i]
+	    vk::DescriptorSetLayoutBinding{.binding = 6,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // history moments read [(i+1)%2]
+	    vk::DescriptorSetLayoutBinding{.binding = 7,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // history moments write [i]
+	    vk::DescriptorSetLayoutBinding{.binding = 8,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // A-Trous ping-pong buffer A
+	    vk::DescriptorSetLayoutBinding{.binding = 9,  .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // A-Trous ping-pong buffer B
+	    vk::DescriptorSetLayoutBinding{.binding = 10, .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // final denoised output (= noisy colour image, reused)
+	    vk::DescriptorSetLayoutBinding{.binding = 11, .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute},   // previous-frame G-Buffer normals [(i+1)%2]
+	    vk::DescriptorSetLayoutBinding{.binding = 12, .descriptorType = vk::DescriptorType::eStorageImage, .descriptorCount = 1, .stageFlags = vk::ShaderStageFlagBits::eCompute}};  // previous-frame G-Buffer depth   [(i+1)%2]
+	vk::DescriptorSetLayoutCreateInfo layoutInfo{
+	    .bindingCount = static_cast<uint32_t>(bindings.size()),
+	    .pBindings    = bindings.data()};
+	denoiserDescriptorSetLayout = vk::raii::DescriptorSetLayout(dev.logicalDevice, layoutInfo);
 }
 
 // ── Pipeline Layout Implementations ────────────────────────────────────────
@@ -551,6 +598,152 @@ void PipelineCollection::createShaderBindingTable(VulkanDevice &dev)
 	hitRegion.deviceAddress = dev.logicalDevice.getBufferAddress(hitInfo);
 	hitRegion.stride        = handleSizeAligned;
 	hitRegion.size          = hitSBTSize;
+}
+
+void PipelineCollection::createClassicRTPipeline(VulkanDevice &dev)
+{
+	// The classic RT pipeline reuses rayTracingPipelineLayout (same descriptor sets and push constants).
+	// Only the shader stages differ: RT_ prefixed shaders with the simple RayPayload.
+	vk::raii::ShaderModule rgenModule  = createShaderModule(dev, readFile("Shaders/RT_Raygen.slang.spv"));
+	vk::raii::ShaderModule rmissModule = createShaderModule(dev, readFile("Shaders/RT_Miss.slang.spv"));
+	vk::raii::ShaderModule rchitModule = createShaderModule(dev, readFile("Shaders/RT_ClosestHit.slang.spv"));
+	vk::raii::ShaderModule ranyModule  = createShaderModule(dev, readFile("Shaders/RT_AnyHit.slang.spv"));
+
+	std::array<vk::PipelineShaderStageCreateInfo, 4> stages = {
+	    vk::PipelineShaderStageCreateInfo{
+	        .stage  = vk::ShaderStageFlagBits::eRaygenKHR,
+	        .module = *rgenModule,
+	        .pName  = "main"},
+	    vk::PipelineShaderStageCreateInfo{
+	        .stage  = vk::ShaderStageFlagBits::eMissKHR,
+	        .module = *rmissModule,
+	        .pName  = "main"},
+	    vk::PipelineShaderStageCreateInfo{
+	        .stage  = vk::ShaderStageFlagBits::eClosestHitKHR,
+	        .module = *rchitModule,
+	        .pName  = "main"},
+	    vk::PipelineShaderStageCreateInfo{
+	        .stage  = vk::ShaderStageFlagBits::eAnyHitKHR,
+	        .module = *ranyModule,
+	        .pName  = "main"}};
+
+	std::array<vk::RayTracingShaderGroupCreateInfoKHR, 3> groups = {
+	    vk::RayTracingShaderGroupCreateInfoKHR{// Group 0 - RayGen
+	                                           .type               = vk::RayTracingShaderGroupTypeKHR::eGeneral,
+	                                           .generalShader      = 0,
+	                                           .closestHitShader   = VK_SHADER_UNUSED_KHR,
+	                                           .anyHitShader       = VK_SHADER_UNUSED_KHR,
+	                                           .intersectionShader = VK_SHADER_UNUSED_KHR},
+	    vk::RayTracingShaderGroupCreateInfoKHR{// Group 1 - Miss
+	                                           .type               = vk::RayTracingShaderGroupTypeKHR::eGeneral,
+	                                           .generalShader      = 1,
+	                                           .closestHitShader   = VK_SHADER_UNUSED_KHR,
+	                                           .anyHitShader       = VK_SHADER_UNUSED_KHR,
+	                                           .intersectionShader = VK_SHADER_UNUSED_KHR},
+	    vk::RayTracingShaderGroupCreateInfoKHR{// Group 2 - Closest Hit + Any Hit
+	                                           .type               = vk::RayTracingShaderGroupTypeKHR::eTrianglesHitGroup,
+	                                           .generalShader      = VK_SHADER_UNUSED_KHR,
+	                                           .closestHitShader   = 2,
+	                                           .anyHitShader       = 3,
+	                                           .intersectionShader = VK_SHADER_UNUSED_KHR}};
+
+	vk::RayTracingPipelineCreateInfoKHR pipelineInfo{
+	    .stageCount                   = static_cast<uint32_t>(stages.size()),
+	    .pStages                      = stages.data(),
+	    .groupCount                   = static_cast<uint32_t>(groups.size()),
+	    .pGroups                      = groups.data(),
+	    .maxPipelineRayRecursionDepth = 2,   // Primary ray + one shadow ray from ClosestHit
+	    .layout                       = *rayTracingPipelineLayout};
+
+	classicRTPipeline = dev.logicalDevice.createRayTracingPipelineKHR(nullptr, nullptr, pipelineInfo);
+}
+
+void PipelineCollection::createClassicRTShaderBindingTable(VulkanDevice &dev)
+{
+	const uint32_t handleSize      = dev.rayTracingProperties.shaderGroupHandleSize;
+	const uint32_t handleAlignment = dev.rayTracingProperties.shaderGroupHandleAlignment;
+	const uint32_t baseAlignment   = dev.rayTracingProperties.shaderGroupBaseAlignment;
+
+	const uint32_t handleSizeAligned = VulkanUtils::alignUp(handleSize, handleAlignment);
+	const uint32_t raygenSBTSize     = VulkanUtils::alignUp(handleSizeAligned, baseAlignment);
+	const uint32_t missSBTSize       = VulkanUtils::alignUp(handleSizeAligned, baseAlignment);
+	const uint32_t hitSBTSize        = VulkanUtils::alignUp(handleSizeAligned, baseAlignment);
+
+	const uint32_t       groupCount = 3;
+	const uint32_t       sbtSize    = groupCount * handleSize;
+	std::vector<uint8_t> handles    = classicRTPipeline.getRayTracingShaderGroupHandlesKHR<uint8_t>(0, groupCount, sbtSize);
+
+	auto createSBTBuffer = [&](vk::raii::Buffer &buffer, vk::raii::DeviceMemory &memory, uint32_t size, void *data, uint32_t handleOffset) {
+		VulkanUtils::createBuffer(
+		    dev.logicalDevice, dev.physicalDevice, size,
+		    vk::BufferUsageFlagBits::eShaderBindingTableKHR | vk::BufferUsageFlagBits::eShaderDeviceAddress,
+		    vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent,
+		    buffer, memory);
+
+		void *mapped = memory.mapMemory(0, size);
+		memcpy(mapped, (uint8_t *) data + handleOffset, handleSize);
+		memory.unmapMemory();
+	};
+
+	createSBTBuffer(classicRTRaygenSBTBuffer, classicRTRaygenSBTMemory, raygenSBTSize, handles.data(), 0);
+	createSBTBuffer(classicRTMissSBTBuffer,   classicRTMissSBTMemory,   missSBTSize,   handles.data(), handleSize);
+	createSBTBuffer(classicRTHitSBTBuffer,    classicRTHitSBTMemory,    hitSBTSize,    handles.data(), handleSize * 2);
+
+	vk::BufferDeviceAddressInfo raygenInfo{.buffer = *classicRTRaygenSBTBuffer};
+	classicRTRaygenRegion.deviceAddress = dev.logicalDevice.getBufferAddress(raygenInfo);
+	classicRTRaygenRegion.stride        = raygenSBTSize;
+	classicRTRaygenRegion.size          = raygenSBTSize;
+
+	vk::BufferDeviceAddressInfo missInfo{.buffer = *classicRTMissSBTBuffer};
+	classicRTMissRegion.deviceAddress = dev.logicalDevice.getBufferAddress(missInfo);
+	classicRTMissRegion.stride        = handleSizeAligned;
+	classicRTMissRegion.size          = missSBTSize;
+
+	vk::BufferDeviceAddressInfo hitInfo{.buffer = *classicRTHitSBTBuffer};
+	classicRTHitRegion.deviceAddress = dev.logicalDevice.getBufferAddress(hitInfo);
+	classicRTHitRegion.stride        = handleSizeAligned;
+	classicRTHitRegion.size          = hitSBTSize;
+}
+
+void PipelineCollection::createDenoiserPipelineLayout(VulkanDevice &dev)
+{
+	vk::PushConstantRange pushRange{
+	    .stageFlags = vk::ShaderStageFlagBits::eCompute,
+	    .offset     = 0,
+	    .size       = sizeof(DenoisePushConstants)};
+	vk::PipelineLayoutCreateInfo info{
+	    .setLayoutCount         = 1,
+	    .pSetLayouts            = &*denoiserDescriptorSetLayout,
+	    .pushConstantRangeCount = 1,
+	    .pPushConstantRanges    = &pushRange};
+	denoiserPipelineLayout = vk::raii::PipelineLayout(dev.logicalDevice, info);
+}
+
+void PipelineCollection::createDenoiserPipelines(VulkanDevice &dev)
+{
+	createDenoiserPipelineLayout(dev);
+
+	// Reprojection compute pipeline
+	{
+		vk::raii::ShaderModule mod = createShaderModule(dev, readFile("Shaders/Reprojection.slang.spv"));
+		vk::PipelineShaderStageCreateInfo stage{
+		    .stage  = vk::ShaderStageFlagBits::eCompute,
+		    .module = *mod,
+		    .pName  = "reprojectionMain"};
+		vk::ComputePipelineCreateInfo info{.stage = stage, .layout = *denoiserPipelineLayout};
+		reprojectionPipeline = vk::raii::Pipeline(dev.logicalDevice, nullptr, info);
+	}
+
+	// A-Trous spatial filter compute pipeline
+	{
+		vk::raii::ShaderModule mod = createShaderModule(dev, readFile("Shaders/Denoiser.slang.spv"));
+		vk::PipelineShaderStageCreateInfo stage{
+		    .stage  = vk::ShaderStageFlagBits::eCompute,
+		    .module = *mod,
+		    .pName  = "atrousMain"};
+		vk::ComputePipelineCreateInfo info{.stage = stage, .layout = *denoiserPipelineLayout};
+		atrousPipeline = vk::raii::Pipeline(dev.logicalDevice, nullptr, info);
+	}
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/Core/PipelineCollection.h
+++ b/src/Core/PipelineCollection.h
@@ -20,6 +20,9 @@ class PipelineCollection
 	void createPhysicsPipeline(VulkanDevice &dev);
 	void createRayTracingPipeline(VulkanDevice &dev);
 	void createShaderBindingTable(VulkanDevice &dev);
+	void createDenoiserPipelines(VulkanDevice &dev);
+	void createClassicRTPipeline(VulkanDevice &dev);
+	void createClassicRTShaderBindingTable(VulkanDevice &dev);
 
 	// ── Descriptor Set Layouts ────────────────────────────────────────────
 	vk::raii::DescriptorSetLayout descriptorSetLayoutGlobal{nullptr};
@@ -27,6 +30,7 @@ class PipelineCollection
 	vk::raii::DescriptorSetLayout computeDescriptorSetLayout{nullptr};
 	vk::raii::DescriptorSetLayout physicsDescriptorSetLayout{nullptr};
 	vk::raii::DescriptorSetLayout rayTracingDescriptorSetLayout{nullptr};
+	vk::raii::DescriptorSetLayout denoiserDescriptorSetLayout{nullptr};
 
 	// ── Pipelines ─────────────────────────────────────────────────────────
 	vk::raii::Pipeline graphicsPipeline{nullptr};
@@ -34,7 +38,12 @@ class PipelineCollection
 	vk::raii::Pipeline computePipeline{nullptr};
 	vk::raii::Pipeline physicsPipeline{nullptr};
 
-	vk::raii::Pipeline rayTracingPipeline{nullptr};
+	vk::raii::Pipeline rayTracingPipeline{nullptr};   // path tracer
+	vk::raii::Pipeline classicRTPipeline{nullptr};    // classic ray tracer (direct illumination)
+
+	// Denoiser: two compute pipelines (temporal reprojection + spatial A-Trous).
+	vk::raii::Pipeline reprojectionPipeline{nullptr};
+	vk::raii::Pipeline atrousPipeline{nullptr};
 
 	// ── Pipeline Layouts ──────────────────────────────────────────────────
 	vk::raii::PipelineLayout graphicsPipelineLayout{nullptr};
@@ -43,8 +52,9 @@ class PipelineCollection
 	vk::raii::PipelineLayout physicsPipelineLayout{nullptr};
 
 	vk::raii::PipelineLayout rayTracingPipelineLayout{nullptr};
+	vk::raii::PipelineLayout denoiserPipelineLayout{nullptr};
 
-	// ── Shader Binding Table (SBT) ────────────────────────────────────────
+	// ── Shader Binding Table (SBT) — Path Tracer ─────────────────────────
 	vk::raii::Buffer                  raygenSBTBuffer{nullptr};
 	vk::raii::DeviceMemory            raygenSBTMemory{nullptr};
 	vk::StridedDeviceAddressRegionKHR raygenRegion{};
@@ -57,12 +67,27 @@ class PipelineCollection
 	vk::raii::DeviceMemory            hitSBTMemory{nullptr};
 	vk::StridedDeviceAddressRegionKHR hitRegion{};
 
+	// ── Shader Binding Table (SBT) — Classic Ray Tracer ──────────────────
+	vk::raii::Buffer                  classicRTRaygenSBTBuffer{nullptr};
+	vk::raii::DeviceMemory            classicRTRaygenSBTMemory{nullptr};
+	vk::StridedDeviceAddressRegionKHR classicRTRaygenRegion{};
+
+	vk::raii::Buffer                  classicRTMissSBTBuffer{nullptr};
+	vk::raii::DeviceMemory            classicRTMissSBTMemory{nullptr};
+	vk::StridedDeviceAddressRegionKHR classicRTMissRegion{};
+
+	vk::raii::Buffer                  classicRTHitSBTBuffer{nullptr};
+	vk::raii::DeviceMemory            classicRTHitSBTMemory{nullptr};
+	vk::StridedDeviceAddressRegionKHR classicRTHitRegion{};
+
   private:
 	void createGlobalDescriptorSetLayout(VulkanDevice &dev);
 	void createMaterialDescriptorSetLayout(VulkanDevice &dev);
 	void createComputeDescriptorSetLayout(VulkanDevice &dev);
 	void createPhysicsDescriptorSetLayout(VulkanDevice &dev);
 	void createRayTracingDescriptorSetLayout(VulkanDevice &dev);
+	void createDenoiserDescriptorSetLayout(VulkanDevice &dev);
+	void createDenoiserPipelineLayout(VulkanDevice &dev);
 	void createGraphicsPipelineLayout(VulkanDevice &dev);
 	void createShadowPipelineLayout(VulkanDevice &dev);
 	void createComputePipelineLayout(VulkanDevice &dev);

--- a/src/Core/UISystem.cpp
+++ b/src/Core/UISystem.cpp
@@ -329,11 +329,14 @@ void UISystem::drawPhysicsUI(Scene &scene, PhysicsSystem &physics,
 	ImGui::Begin("Engine Controls");
 
 	ImGui::Text("Rendering Backend:");
-	if (ImGui::RadioButton("Rasterizer", !useRayTracing))
-		useRayTracing = false;
+	if (ImGui::RadioButton("Rasterizer", renderMode == RenderMode::Rasterizer))
+		renderMode = RenderMode::Rasterizer;
 	ImGui::SameLine();
-	if (ImGui::RadioButton("Ray Tracer (RTX)", useRayTracing))
-		useRayTracing = true;
+	if (ImGui::RadioButton("Ray Tracer", renderMode == RenderMode::RayTracer))
+		renderMode = RenderMode::RayTracer;
+	ImGui::SameLine();
+	if (ImGui::RadioButton("Path Tracer", renderMode == RenderMode::PathTracer))
+		renderMode = RenderMode::PathTracer;
 
 	ImGui::Separator();
 

--- a/src/Core/UISystem.h
+++ b/src/Core/UISystem.h
@@ -25,9 +25,9 @@ class UISystem
 	void cleanup();
 
 	// ── State shared with EngineCore's main loop ──────────────────────────────
-	bool      useGPUPhysics     = false;
-	bool      useRayTracing     = false;
-	bool      simulationRunning = false;
+	bool       useGPUPhysics     = false;
+	RenderMode renderMode        = RenderMode::Rasterizer;
+	bool       simulationRunning = false;
 	float     physicsTime       = 0.0f;        // updated by EngineCore after each tick
 	glm::vec3 lightDirection    = glm::vec3(-0.25f, -1.0f, 0.0f);
 

--- a/src/Core/VulkanUtils.cpp
+++ b/src/Core/VulkanUtils.cpp
@@ -221,6 +221,15 @@ void recordImageLayoutTransition(const vk::raii::CommandBuffer &commandBuffer, v
 		sourceStage           = vk::PipelineStageFlagBits::eTopOfPipe;
 		destinationStage      = vk::PipelineStageFlagBits::eEarlyFragmentTests | vk::PipelineStageFlagBits::eLateFragmentTests;
 	}
+	else if (oldLayout == vk::ImageLayout::eUndefined && newLayout == vk::ImageLayout::eGeneral)
+	{
+		// Used to initialize storage images (eStorage) before the first compute/RT write.
+		// No previous content to preserve; any subsequent access will issue its own barrier.
+		barrier.srcAccessMask = {};
+		barrier.dstAccessMask = vk::AccessFlagBits::eShaderWrite;
+		sourceStage           = vk::PipelineStageFlagBits::eTopOfPipe;
+		destinationStage      = vk::PipelineStageFlagBits::eComputeShader;
+	}
 	else
 	{
 		throw std::invalid_argument("unsupported layout transition!");

--- a/src/shaders/ClosestHit.slang
+++ b/src/shaders/ClosestHit.slang
@@ -1,16 +1,28 @@
 #include "ShaderCommon.slang"
 
+// Path tracer RayPayload — surface properties returned by ClosestHit to Raygen.
+struct RayPayload {
+    float3 albedo;
+    float3 emission;
+    float3 worldNormal;
+    float3 hitPos;
+    float  roughness;
+    float  metallic;
+    float3 F0;
+    float  hitT;
+    uint   instanceID;
+};
+
 struct BuiltInTriangleIntersectionAttributes {
     float2 barycentrics;
 };
 
-// Set 0 Bindings
+// Set 0 Bindings (bindings 2-4 are now G-Buffer images written by Raygen, not ClosestHit)
 [[vk::binding(0, 0)]] RaytracingAccelerationStructure topLevelAS;
-[[vk::binding(1, 0)]] RWTexture2D<float4> image;
-[[vk::binding(2, 0)]] ByteAddressBuffer globalVertices[];
-[[vk::binding(3, 0)]] ByteAddressBuffer globalIndices[];
-[[vk::binding(4, 0)]] StructuredBuffer<MaterialData> globalMaterials[];
-[[vk::binding(5, 0)]] Sampler2D globalTextures[];
+[[vk::binding(5, 0)]] ByteAddressBuffer globalVertices[];
+[[vk::binding(6, 0)]] ByteAddressBuffer globalIndices[];
+[[vk::binding(7, 0)]] StructuredBuffer<MaterialData> globalMaterials[];
+[[vk::binding(8, 0)]] Sampler2D globalTextures[];
 
 // Set 1 Bindings
 [[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
@@ -44,16 +56,15 @@ uint loadIndex(ByteAddressBuffer buf, uint idx)
 [shader("closesthit")]
 void main(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attribs) {
 
-    uint customIndex    = InstanceID();
-    uint modelId        = customIndex >> 14;
+    uint customIndex     = InstanceID();
+    uint modelId         = customIndex >> 14;
     uint primitiveOffset = customIndex & 0x3FFF;
-    uint geometryIndex  = GeometryIndex();
+    uint geometryIndex   = GeometryIndex();
 
     MaterialData mat = globalMaterials[NonUniformResourceIndex(modelId)][primitiveOffset + geometryIndex];
 
-    uint firstIndex  = mat.firstIndex;
+    uint firstIndex   = mat.firstIndex;
     uint vertexOffset = mat.vertexOffset;
-
     uint primitiveIndex = PrimitiveIndex();
 
     ByteAddressBuffer vertBuf = globalVertices[NonUniformResourceIndex(modelId)];
@@ -67,176 +78,84 @@ void main(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes att
     Vertex v1 = loadVertex(vertBuf, vertexOffset + i1);
     Vertex v2 = loadVertex(vertBuf, vertexOffset + i2);
 
-    float3 barycentrics = float3(1.0 - attribs.barycentrics.x - attribs.barycentrics.y, attribs.barycentrics.x, attribs.barycentrics.y);
+    float3 barycentrics = float3(
+        1.0 - attribs.barycentrics.x - attribs.barycentrics.y,
+        attribs.barycentrics.x,
+        attribs.barycentrics.y);
 
-    float3 normal = v0.normal * barycentrics.x + v1.normal * barycentrics.y + v2.normal * barycentrics.z;
-    float2 uv     = v0.texCoord * barycentrics.x + v1.texCoord * barycentrics.y + v2.texCoord * barycentrics.z;
+    float2 uv = v0.texCoord * barycentrics.x + v1.texCoord * barycentrics.y + v2.texCoord * barycentrics.z;
 
-    // Correct normal transform: transpose(inverse(ObjectToWorld)) = transpose(WorldToObject).
-    // mul(row_vec, M) = M^T * col_vec, so mul(normal, WorldToObject_33) gives the right result.
-    float3 worldNormal = normalize(mul(normal, (float3x3)WorldToObject3x4()));
+    // World-space shading normal: transpose(inverse(ObjectToWorld)) = transpose(WorldToObject).
+    float3 geomNormal = v0.normal * barycentrics.x + v1.normal * barycentrics.y + v2.normal * barycentrics.z;
+    float3 N = normalize(mul(geomNormal, (float3x3)WorldToObject3x4()));
+    // Flip toward ray origin so backface hits (eTriangleFacingCullDisable) shade correctly.
+    // Must happen before TBN construction so the tangent frame inherits the right orientation.
+    if (dot(N, WorldRayDirection()) > 0.0)
+        N = -N;
 
-    float3 hitPos = WorldRayOrigin() + WorldRayDirection() * RayTCurrent();
-    float3 V = normalize(ubo.cameraPos.xyz - hitPos);
-
-    // ========================================================================
-    // Base Color
-    // ========================================================================
-    float4 baseColor = mat.baseColorFactor;
-    if (mat.baseColorIndex >= 0) {
-        float4 sampled = globalTextures[NonUniformResourceIndex(mat.baseColorIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
-        baseColor.rgb *= sRGBToLinear(sampled.rgb);
-        baseColor.a *= sampled.a;
-    }
-
-    // ========================================================================
-    // Metallic-Roughness
-    // ========================================================================
-    float metallic = mat.metallicFactor;
-    float roughness = mat.roughnessFactor;
-
-    if (mat.metallicRoughnessIndex >= 0) {
-        float4 mrSample = globalTextures[NonUniformResourceIndex(mat.metallicRoughnessIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
-        roughness *= mrSample.g;
-        metallic *= mrSample.b;
-    }
-    roughness = clamp(roughness, MIN_ROUGHNESS, 1.0);
-
-    // ========================================================================
-    // Normal Mapping
-    // ========================================================================
-    float3 N = normalize(worldNormal);
-
+    // Normal mapping
     if (mat.normalIndex >= 0) {
-        float3 T = normalize(mul((float3x3)ObjectToWorld3x4(), v0.tangent.xyz * barycentrics.x + v1.tangent.xyz * barycentrics.y + v2.tangent.xyz * barycentrics.z));
+        float3 T = normalize(mul((float3x3)ObjectToWorld3x4(),
+            v0.tangent.xyz * barycentrics.x + v1.tangent.xyz * barycentrics.y + v2.tangent.xyz * barycentrics.z));
         float tangentW = v0.tangent.w * barycentrics.x + v1.tangent.w * barycentrics.y + v2.tangent.w * barycentrics.z;
 
-        float tangentLengthSq = dot(T, T);
-        if (tangentLengthSq > 0.0001) {
-            T = T * rsqrt(tangentLengthSq);
+        float tls = dot(T, T);
+        if (tls > 0.0001) {
+            T = T * rsqrt(tls);
             T = T - N * dot(N, T);
-            tangentLengthSq = dot(T, T);
-
-            if (tangentLengthSq > 0.0001) {
-                T = T * rsqrt(tangentLengthSq);
+            tls = dot(T, T);
+            if (tls > 0.0001) {
+                T = T * rsqrt(tls);
                 float3 B = cross(N, T) * tangentW;
 
                 float3 sampledNormal = globalTextures[NonUniformResourceIndex(mat.normalIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).rgb;
                 float3 tangentNormal = sampledNormal * 2.0 - 1.0;
                 tangentNormal.xy *= mat.normalScale;
                 tangentNormal = normalize(tangentNormal);
-
-                float3x3 TBN = float3x3(T, B, N);
-                N = normalize(mul(tangentNormal, TBN));
+                N = normalize(mul(tangentNormal, float3x3(T, B, N)));
             }
         }
     }
 
-    // ========================================================================
-    // Ambient Occlusion
-    // ========================================================================
-    float ao = 1.0;
-    if (mat.occlusionIndex >= 0) {
-        float aoSample = globalTextures[NonUniformResourceIndex(mat.occlusionIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).r;
-        ao = 1.0 + mat.occlusionStrength * (aoSample - 1.0);
+    // Base colour
+    float4 baseColor = mat.baseColorFactor;
+    if (mat.baseColorIndex >= 0) {
+        float4 sampled = globalTextures[NonUniformResourceIndex(mat.baseColorIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
+        baseColor.rgb *= sRGBToLinear(sampled.rgb);
+        baseColor.a   *= sampled.a;
     }
 
-    // ========================================================================
+    // Metallic-roughness
+    float metallic  = mat.metallicFactor;
+    float roughness = mat.roughnessFactor;
+    if (mat.metallicRoughnessIndex >= 0) {
+        float4 mr = globalTextures[NonUniformResourceIndex(mat.metallicRoughnessIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
+        roughness *= mr.g;
+        metallic  *= mr.b;
+    }
+    roughness = clamp(roughness, MIN_ROUGHNESS, 1.0);
+
     // Emissive
-    // ========================================================================
     float3 emissive = mat.emissiveFactor;
     if (mat.emissiveIndex >= 0) {
-        float3 emissiveSample = globalTextures[NonUniformResourceIndex(mat.emissiveIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).rgb;
-        emissive *= sRGBToLinear(emissiveSample);
+        emissive *= sRGBToLinear(
+            globalTextures[NonUniformResourceIndex(mat.emissiveIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).rgb);
     }
 
-    // Dielectric Specular
-    float dielectricSpecular = mat.specularFactor;
-    if (mat.specularTextureIndex >= 0) {
-        dielectricSpecular *= globalTextures[NonUniformResourceIndex(mat.specularTextureIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).a;
-    }
-    float3 F0 = float3(0.08 * dielectricSpecular, 0.08 * dielectricSpecular, 0.08 * dielectricSpecular);
-    F0 = lerp(F0, baseColor.rgb, metallic);
+    // Fresnel base reflectance
+    float dielectricSpec = mat.specularFactor;
+    if (mat.specularTextureIndex >= 0)
+        dielectricSpec *= globalTextures[NonUniformResourceIndex(mat.specularTextureIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).a;
+    float3 F0 = lerp(float3(0.08 * dielectricSpec), baseColor.rgb, metallic);
 
-    float3 Lo = float3(0.0);
-
-    // ========================================================================
-    // RT Shadow
-    // ========================================================================
-    float3 L = normalize(-ubo.lightDir.xyz);
-    
-    // Slight offset to prevent shadow acne
-    float3 shadowRayOrigin = hitPos + N * 0.005;
-    
-    RayDesc shadowRay;
-    shadowRay.Origin = shadowRayOrigin;
-    shadowRay.Direction = L;
-    shadowRay.TMin = 0.005;
-    shadowRay.TMax = 10000.0;
-
-    RayPayload shadowPayload;
-    shadowPayload.color = float3(0.0);
-    shadowPayload.isShadowed = 1;
-
-    // Call TraceRay for shadow (skip Closest Hit)
-    TraceRay(topLevelAS, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER, 0xFF, 0, 0, 0, shadowRay, shadowPayload);
-
-    // If shadowPayload.isShadowed == 1, point is occluded. 
-    float shadow = float(shadowPayload.isShadowed);
-
-    // Sun light
-    {
-        float3 H = normalize(V + L);
-        float3 radiance = float3(1.0, 0.98, 0.95) * 3.0;
-
-        float NdotL = max(dot(N, L), 0.0);
-        float NdotV = max(dot(N, V), 0.0);
-
-        float D = distributionGGX(N, H, roughness);
-        float G = geometrySmith(N, V, L, roughness);
-        float3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
-
-        float3 specular = (D * G * F) / max(4.0 * NdotV * NdotL, 0.0001);
-        float3 kD = (1.0 - F) * (1.0 - metallic);
-        float3 diffuse = kD * baseColor.rgb / PI;
-
-        Lo += (diffuse + specular) * radiance * NdotL * (1.0 - shadow);
-    }
-
-    // Fill light
-    {
-        float3 fillL = normalize(float3(-0.3, 0.5, -0.5));
-        float3 H = normalize(V + fillL);
-        float3 radiance = float3(0.6, 0.7, 0.9) * 0.5;
-
-        float NdotL = max(dot(N, fillL), 0.0);
-        float NdotV = max(dot(N, V), 0.0);
-
-        float D = distributionGGX(N, H, roughness);
-        float G = geometrySmith(N, V, fillL, roughness);
-        float3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
-
-        float3 specular = (D * G * F) / max(4.0 * NdotV * NdotL, 0.0001);
-        float3 kD = (1.0 - F) * (1.0 - metallic);
-        float3 diffuse = kD * baseColor.rgb / PI;
-
-        Lo += (diffuse + specular) * radiance * NdotL; // No shadows for fill light
-    }
-
-    // Ambient
-    float3 skyColor = float3(0.3, 0.4, 0.6);
-    float3 groundColor = float3(0.1, 0.08, 0.06);
-    float3 ambientL = lerp(groundColor, skyColor, N.y * 0.5 + 0.5);
-
-    float3 kS = fresnelSchlickRoughness(max(dot(N, V), 0.0), F0, roughness);
-    float3 kD_amb = (1.0 - kS) * (1.0 - metallic);
-
-    float3 ambientDiffuse = kD_amb * baseColor.rgb * ambientL;
-    float3 ambientSpecular = kS * ambientL * (1.0 - roughness * 0.5);
-    float3 ambientContribution = (ambientDiffuse + ambientSpecular) * ao * 0.3;
-
-    float3 finalColor = ambientContribution + Lo + emissive;
-    finalColor = acesTonemap(finalColor);
-
-    payload.color = finalColor;
+    // Return surface properties — Raygen does all lighting via the path tracing loop.
+    payload.albedo      = baseColor.rgb;
+    payload.emission    = emissive;
+    payload.worldNormal = N;
+    payload.hitPos      = WorldRayOrigin() + WorldRayDirection() * RayTCurrent();
+    payload.roughness   = roughness;
+    payload.metallic    = metallic;
+    payload.F0          = F0;
+    payload.hitT        = RayTCurrent();
+    payload.instanceID  = InstanceID();
 }

--- a/src/shaders/Denoiser.slang
+++ b/src/shaders/Denoiser.slang
@@ -1,0 +1,109 @@
+#include "ShaderCommon.slang"
+
+// Denoiser descriptor set (Set 0) — all storage images.
+[[vk::binding(1,  0)]] RWTexture2D<float4> gBufferNormals;     // G-Buffer normals (edge-stopping)
+[[vk::binding(2,  0)]] RWTexture2D<float>  gBufferDepth;       // G-Buffer depth (edge-stopping)
+[[vk::binding(7,  0)]] RWTexture2D<float2> historyMomentsOut;  // variance estimate (R=mean, G=mean²)
+[[vk::binding(8,  0)]] RWTexture2D<float4> atrousTempA;        // A-Trous ping-pong buffer A
+[[vk::binding(9,  0)]] RWTexture2D<float4> atrousTempB;        // A-Trous ping-pong buffer B
+[[vk::binding(10, 0)]] RWTexture2D<float4> finalOutput;        // final denoised output (last pass only)
+
+struct DenoisePushConstants {
+    int   stepSize;    // 1, 2, 4, 8, 16 for iterations 0-4
+    int   isLastPass;  // 1 on iteration 4: write to finalOutput with tone mapping
+    float phiColor;    // luminance edge-stopping weight (typical: 10.0)
+    float phiNormal;   // normal edge-stopping exponent  (typical: 128.0)
+};
+[[vk::push_constant]] DenoisePushConstants push;
+
+float luminance(float3 c) { return dot(c, float3(0.2126, 0.7152, 0.0722)); }
+
+// A-Trous 5×5 kernel weights (separable gaussian approximation used in SVGF).
+static const float kWeights[3] = { 3.0 / 8.0, 1.0 / 4.0, 1.0 / 16.0 };
+
+[shader("compute")]
+[numthreads(16, 16, 1)]
+void atrousMain(uint3 dispatchID : SV_DispatchThreadID)
+{
+    uint2 dims;
+    atrousTempA.GetDimensions(dims.x, dims.y);
+    uint2 pixel = dispatchID.xy;
+    if (pixel.x >= dims.x || pixel.y >= dims.y) return;
+
+    // Determine which ping-pong buffer is the input this iteration.
+    // Iteration i: input is A if (i % 2 == 0), B if (i % 2 == 1).
+    // stepSize tells us the iteration index: iter = log2(stepSize).
+    int  iter  = (push.stepSize == 1) ? 0 :
+                 (push.stepSize == 2) ? 1 :
+                 (push.stepSize == 4) ? 2 :
+                 (push.stepSize == 8) ? 3 : 4;
+    bool readA = (iter % 2 == 0);
+
+    float3 centerColor = readA ? atrousTempA[pixel].rgb : atrousTempB[pixel].rgb;
+    // Sky pixels write a zero normal (length = 0); guard against the NaN that normalize() would produce.
+    float3 rawNorm    = gBufferNormals[pixel].xyz;
+    float3 centerNorm  = (dot(rawNorm, rawNorm) > 0.0001) ? normalize(rawNorm) : float3(0.0, 0.0, 1.0);
+    float  centerDepth = gBufferDepth[pixel];
+
+    // Variance from temporal moments: var = E[x²] - E[x]²
+    // Clamp to a minimum so the luminance edge-stopping (phiColor * sqrt(variance)) never
+    // collapses to zero on the first frame when there is no temporal history yet.
+    // Without this floor, all neighbor weights become ~0 and the A-Trous filter degenerates
+    // into a pass-through, preserving raw 1-SPP salt-and-pepper noise.
+    float2 moments  = historyMomentsOut[pixel];
+    float  variance = max(moments.y - moments.x * moments.x, 0.01);
+    float  centerLum = luminance(centerColor);
+
+    float3 colorSum  = float3(0.0, 0.0, 0.0);
+    float  weightSum = 0.0;
+
+    // 5×5 A-Trous kernel (step size doubles each iteration for O(N log N) coverage).
+    for (int dy = -2; dy <= 2; ++dy)
+    {
+        for (int dx = -2; dx <= 2; ++dx)
+        {
+            int2  samplePixel = int2(pixel) + int2(dx, dy) * push.stepSize;
+            float kernelW     = kWeights[abs(dx)] * kWeights[abs(dy)];
+
+            // Clamp to image boundary.
+            samplePixel = clamp(samplePixel, int2(0, 0), int2(dims) - int2(1, 1));
+
+            float3 sampleColor   = readA ? atrousTempA[samplePixel].rgb : atrousTempB[samplePixel].rgb;
+            float3 rawSampleNorm = gBufferNormals[samplePixel].xyz;
+            float3 sampleNorm    = (dot(rawSampleNorm, rawSampleNorm) > 0.0001) ? normalize(rawSampleNorm) : float3(0.0, 0.0, 1.0);
+            float  sampleDepth   = gBufferDepth[samplePixel];
+
+            // Normal edge-stopping: high power to sharply preserve geometry boundaries.
+            float normalW = pow(max(dot(centerNorm, sampleNorm), 0.0), push.phiNormal);
+
+            // Depth edge-stopping: exponential falloff on relative depth difference.
+            float depthDiff = abs(centerDepth - sampleDepth) / max(abs(centerDepth), 0.001);
+            float depthW    = exp(-depthDiff * 10.0);
+
+            // Luminance edge-stopping: variance-guided (tighter in low-variance regions).
+            float lumDiff  = abs(centerLum - luminance(sampleColor));
+            float lumW     = exp(-lumDiff / max(push.phiColor * sqrt(variance) + 0.0001, 0.0001));
+
+            float w = kernelW * normalW * depthW * lumW;
+            colorSum  += sampleColor * w;
+            weightSum += w;
+        }
+    }
+
+    float3 filtered = colorSum / max(weightSum, 0.0001);
+
+    if (push.isLastPass != 0) {
+        // Final iteration: apply tone mapping and write to the denoised output image.
+        // The swapchain is B8G8R8A8_SRGB, so the blit automatically applies the
+        // sRGB transfer function. Do NOT call linearToSRGB here — that would apply
+        // gamma twice and wash out all dark values to mid-grey.
+        float3 tonemapped = acesTonemap(filtered);
+        finalOutput[pixel] = float4(tonemapped, 1.0);
+    } else {
+        // Intermediate iteration: write to the OTHER ping-pong buffer.
+        if (readA)
+            atrousTempB[pixel] = float4(filtered, 1.0);
+        else
+            atrousTempA[pixel] = float4(filtered, 1.0);
+    }
+}

--- a/src/shaders/LaphriaEngine.slang
+++ b/src/shaders/LaphriaEngine.slang
@@ -247,10 +247,11 @@ float4 fragMain(VSOutput input) : SV_TARGET {
         Lo += (diffuse + specular) * radiance * NdotL;
     }
 
-    // Ambient
-    float3 skyColor = float3(0.3, 0.4, 0.6);
-    float3 groundColor = float3(0.1, 0.08, 0.06);
-    float3 ambient = lerp(groundColor, skyColor, N.y * 0.5 + 0.5);
+    // Ambient — sky/ground colours driven by the same procedural sky model.
+    float3 sunDir3     = normalize(-ubo.lightDir.xyz);
+    float3 skyColor    = evalSkyColor(float3(0.0, 1.0, 0.0), sunDir3); // zenith sky sample
+    float3 groundColor = evalGroundColor(sunDir3);                      // earth-toned lower lobe
+    float3 ambient     = lerp(groundColor, skyColor, N.y * 0.5 + 0.5);
 
     float3 kS = fresnelSchlickRoughness(max(dot(N, V), 0.0), F0, roughness);
     float3 kD = (1.0 - kS) * (1.0 - metallic);

--- a/src/shaders/Miss.slang
+++ b/src/shaders/Miss.slang
@@ -1,18 +1,33 @@
 #include "ShaderCommon.slang"
 
+// Path tracer RayPayload — surface properties returned by ClosestHit to Raygen.
+struct RayPayload {
+    float3 albedo;
+    float3 emission;
+    float3 worldNormal;
+    float3 hitPos;
+    float  roughness;
+    float  metallic;
+    float3 F0;
+    float  hitT;
+    uint   instanceID;
+};
+
+// Set 1 — global UBO (needed for lightDir → sun direction).
+[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
+
 [shader("miss")]
 void main(inout RayPayload payload) {
-    if (payload.isShadowed == 1) {
-        payload.isShadowed = 0; // Not occluded
-        return;
-    }
-
-    // Return a nice background sky color gradient using the ray direction
     float3 rayDir = normalize(WorldRayDirection());
-    
-    float t = 0.5 * (rayDir.y + 1.0);
-    float3 white = float3(1.0, 1.0, 1.0);
-    float3 blue = float3(0.3, 0.4, 0.6); // Matches regular pipeline sky ambient color
-    
-    payload.color = lerp(white, blue, t);
+    float3 sunDir = normalize(-ubo.lightDir.xyz); // FROM scene TOWARD sun
+
+    payload.emission    = evalSkyColor(rayDir, sunDir);
+    payload.hitT        = -1.0;   // Negative sentinel: ray escaped to sky, no surface hit.
+    payload.albedo      = float3(0.0, 0.0, 0.0);
+    payload.worldNormal = -rayDir;
+    payload.hitPos      = WorldRayOrigin() + WorldRayDirection() * 10000.0;
+    payload.roughness   = 1.0;
+    payload.metallic    = 0.0;
+    payload.F0          = float3(0.0, 0.0, 0.0);
+    payload.instanceID  = 0;
 }

--- a/src/shaders/RT_AnyHit.slang
+++ b/src/shaders/RT_AnyHit.slang
@@ -1,24 +1,16 @@
 #include "ShaderCommon.slang"
 
-// Path tracer RayPayload — surface properties returned by ClosestHit to Raygen.
+// Classic ray tracer RayPayload.
 struct RayPayload {
-    float3 albedo;
-    float3 emission;
-    float3 worldNormal;
-    float3 hitPos;
-    float  roughness;
-    float  metallic;
-    float3 F0;
-    float  hitT;
-    uint   instanceID;
+    float3 color;
+    uint   isShadowed;
 };
 
 struct BuiltInTriangleIntersectionAttributes {
     float2 barycentrics;
 };
 
-// Set 0 Bindings — must match createRayTracingDescriptorSetLayout() in PipelineCollection.cpp.
-// Bindings 1-4 are G-Buffer/RT output images written by Raygen; AnyHit doesn't use them.
+// Set 0 Bindings — binding numbers match the shared RT/PT descriptor set layout.
 [[vk::binding(0, 0)]] RaytracingAccelerationStructure topLevelAS;
 [[vk::binding(5, 0)]] ByteAddressBuffer globalVertices[];
 [[vk::binding(6, 0)]] ByteAddressBuffer globalIndices[];
@@ -44,18 +36,18 @@ uint loadIndex(ByteAddressBuffer buf, uint idx)
 [shader("anyhit")]
 void main(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attribs) {
 
-    uint customIndex    = InstanceID();
-    uint modelId        = customIndex >> 14;
+    uint customIndex     = InstanceID();
+    uint modelId         = customIndex >> 14;
     uint primitiveOffset = customIndex & 0x3FFF;
-    uint geometryIndex  = GeometryIndex();
+    uint geometryIndex   = GeometryIndex();
 
     MaterialData mat = globalMaterials[NonUniformResourceIndex(modelId)][primitiveOffset + geometryIndex];
 
     if (mat.alphaCutoff <= 0.0) {
-        return; // alphaCutoff disabled — accept all hits without a texture lookup
+        return;  // alphaCutoff disabled — accept all hits without a texture lookup.
     }
 
-    uint firstIndex  = mat.firstIndex;
+    uint firstIndex   = mat.firstIndex;
     uint vertexOffset = mat.vertexOffset;
     uint primitiveIndex = PrimitiveIndex();
 

--- a/src/shaders/RT_ClosestHit.slang
+++ b/src/shaders/RT_ClosestHit.slang
@@ -1,0 +1,217 @@
+#include "ShaderCommon.slang"
+
+// Classic ray tracer RayPayload.
+struct RayPayload {
+    float3 color;
+    uint   isShadowed;
+};
+
+struct BuiltInTriangleIntersectionAttributes {
+    float2 barycentrics;
+};
+
+// Set 0 Bindings — binding numbers match the shared RT/PT descriptor set layout.
+// Bindings 2-4 (G-buffer images) are declared in the layout but not used here.
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure topLevelAS;
+[[vk::binding(5, 0)]] ByteAddressBuffer globalVertices[];
+[[vk::binding(6, 0)]] ByteAddressBuffer globalIndices[];
+[[vk::binding(7, 0)]] StructuredBuffer<MaterialData> globalMaterials[];
+[[vk::binding(8, 0)]] Sampler2D globalTextures[];
+
+// Set 1 Bindings
+[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
+
+// C++ Vertex layout (EngineAuxiliary.h):
+//   float3 pos:      offset  0 (12 bytes)
+//   float3 normal:   offset 12 (12 bytes)
+//   float4 tangent:  offset 24 (16 bytes)
+//   float2 texCoord: offset 40 ( 8 bytes)
+//   float3 color:    offset 48 (12 bytes)
+//   stride: 60 bytes
+static const uint kVertexStride = 60;
+
+Vertex loadVertex(ByteAddressBuffer buf, uint idx)
+{
+    uint base  = idx * kVertexStride;
+    Vertex v;
+    v.pos      = asfloat(buf.Load3(base));
+    v.normal   = asfloat(buf.Load3(base + 12));
+    v.tangent  = asfloat(buf.Load4(base + 24));
+    v.texCoord = asfloat(buf.Load2(base + 40));
+    v.color    = asfloat(buf.Load3(base + 48));
+    return v;
+}
+
+uint loadIndex(ByteAddressBuffer buf, uint idx)
+{
+    return buf.Load(idx * 4);
+}
+
+[shader("closesthit")]
+void main(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attribs) {
+
+    uint customIndex     = InstanceID();
+    uint modelId         = customIndex >> 14;
+    uint primitiveOffset = customIndex & 0x3FFF;
+    uint geometryIndex   = GeometryIndex();
+
+    MaterialData mat = globalMaterials[NonUniformResourceIndex(modelId)][primitiveOffset + geometryIndex];
+
+    uint firstIndex   = mat.firstIndex;
+    uint vertexOffset = mat.vertexOffset;
+    uint primitiveIndex = PrimitiveIndex();
+
+    ByteAddressBuffer vertBuf = globalVertices[NonUniformResourceIndex(modelId)];
+    ByteAddressBuffer idxBuf  = globalIndices[NonUniformResourceIndex(modelId)];
+
+    uint i0 = loadIndex(idxBuf, firstIndex + primitiveIndex * 3 + 0);
+    uint i1 = loadIndex(idxBuf, firstIndex + primitiveIndex * 3 + 1);
+    uint i2 = loadIndex(idxBuf, firstIndex + primitiveIndex * 3 + 2);
+
+    Vertex v0 = loadVertex(vertBuf, vertexOffset + i0);
+    Vertex v1 = loadVertex(vertBuf, vertexOffset + i1);
+    Vertex v2 = loadVertex(vertBuf, vertexOffset + i2);
+
+    float3 barycentrics = float3(1.0 - attribs.barycentrics.x - attribs.barycentrics.y, attribs.barycentrics.x, attribs.barycentrics.y);
+
+    float3 normal = v0.normal * barycentrics.x + v1.normal * barycentrics.y + v2.normal * barycentrics.z;
+    float2 uv     = v0.texCoord * barycentrics.x + v1.texCoord * barycentrics.y + v2.texCoord * barycentrics.z;
+
+    // Correct normal transform: transpose(inverse(ObjectToWorld)) = transpose(WorldToObject).
+    // mul(row_vec, M) = M^T * col_vec, so mul(normal, WorldToObject_33) gives the right result.
+    float3 worldNormal = normalize(mul(normal, (float3x3)WorldToObject3x4()));
+
+    float3 hitPos = WorldRayOrigin() + WorldRayDirection() * RayTCurrent();
+    float3 V = normalize(ubo.cameraPos.xyz - hitPos);
+
+    // Base Color
+    float4 baseColor = mat.baseColorFactor;
+    if (mat.baseColorIndex >= 0) {
+        float4 sampled = globalTextures[NonUniformResourceIndex(mat.baseColorIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
+        baseColor.rgb *= sRGBToLinear(sampled.rgb);
+        baseColor.a *= sampled.a;
+    }
+
+    // Metallic-Roughness
+    float metallic  = mat.metallicFactor;
+    float roughness = mat.roughnessFactor;
+    if (mat.metallicRoughnessIndex >= 0) {
+        float4 mrSample = globalTextures[NonUniformResourceIndex(mat.metallicRoughnessIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0);
+        roughness *= mrSample.g;
+        metallic  *= mrSample.b;
+    }
+    roughness = clamp(roughness, MIN_ROUGHNESS, 1.0);
+
+    // Normal Mapping
+    float3 N = normalize(worldNormal);
+    if (mat.normalIndex >= 0) {
+        float3 T = normalize(mul((float3x3)ObjectToWorld3x4(), v0.tangent.xyz * barycentrics.x + v1.tangent.xyz * barycentrics.y + v2.tangent.xyz * barycentrics.z));
+        float tangentW = v0.tangent.w * barycentrics.x + v1.tangent.w * barycentrics.y + v2.tangent.w * barycentrics.z;
+
+        float tangentLengthSq = dot(T, T);
+        if (tangentLengthSq > 0.0001) {
+            T = T * rsqrt(tangentLengthSq);
+            T = T - N * dot(N, T);
+            tangentLengthSq = dot(T, T);
+            if (tangentLengthSq > 0.0001) {
+                T = T * rsqrt(tangentLengthSq);
+                float3 B = cross(N, T) * tangentW;
+
+                float3 sampledNormal = globalTextures[NonUniformResourceIndex(mat.normalIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).rgb;
+                float3 tangentNormal = sampledNormal * 2.0 - 1.0;
+                tangentNormal.xy *= mat.normalScale;
+                tangentNormal = normalize(tangentNormal);
+
+                float3x3 TBN = float3x3(T, B, N);
+                N = normalize(mul(tangentNormal, TBN));
+            }
+        }
+    }
+
+    // Ambient Occlusion
+    float ao = 1.0;
+    if (mat.occlusionIndex >= 0) {
+        float aoSample = globalTextures[NonUniformResourceIndex(mat.occlusionIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).r;
+        ao = 1.0 + mat.occlusionStrength * (aoSample - 1.0);
+    }
+
+    // Emissive
+    float3 emissive = mat.emissiveFactor;
+    if (mat.emissiveIndex >= 0) {
+        float3 emissiveSample = globalTextures[NonUniformResourceIndex(mat.emissiveIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).rgb;
+        emissive *= sRGBToLinear(emissiveSample);
+    }
+
+    // Fresnel base reflectance
+    float dielectricSpecular = mat.specularFactor;
+    if (mat.specularTextureIndex >= 0) {
+        dielectricSpecular *= globalTextures[NonUniformResourceIndex(mat.specularTextureIndex + mat.globalTextureOffset)].SampleLevel(uv, 0.0).a;
+    }
+    float3 F0 = float3(0.08 * dielectricSpecular, 0.08 * dielectricSpecular, 0.08 * dielectricSpecular);
+    F0 = lerp(F0, baseColor.rgb, metallic);
+
+    float3 Lo = float3(0.0);
+
+    // RT Shadow
+    float3 L = normalize(-ubo.lightDir.xyz);
+
+    float3 shadowRayOrigin = hitPos + N * 0.005;
+    RayDesc shadowRay;
+    shadowRay.Origin    = shadowRayOrigin;
+    shadowRay.Direction = L;
+    shadowRay.TMin      = 0.005;
+    shadowRay.TMax      = 10000.0;
+
+    RayPayload shadowPayload;
+    shadowPayload.color      = float3(0.0);
+    shadowPayload.isShadowed = 1;
+
+    TraceRay(topLevelAS, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER, 0xFF, 0, 0, 0, shadowRay, shadowPayload);
+
+    float shadow = float(shadowPayload.isShadowed);
+
+    // Sun light
+    {
+        float3 H       = normalize(V + L);
+        float3 radiance = float3(1.0, 0.98, 0.95) * 3.0;
+        float  NdotL   = max(dot(N, L), 0.0);
+        float  NdotV   = max(dot(N, V), 0.0);
+        float  D       = distributionGGX(N, H, roughness);
+        float  G       = geometrySmith(N, V, L, roughness);
+        float3 F       = fresnelSchlick(max(dot(H, V), 0.0), F0);
+        float3 specular = (D * G * F) / max(4.0 * NdotV * NdotL, 0.0001);
+        float3 kD      = (1.0 - F) * (1.0 - metallic);
+        float3 diffuse = kD * baseColor.rgb / PI;
+        Lo += (diffuse + specular) * radiance * NdotL * (1.0 - shadow);
+    }
+
+    // Fill light
+    {
+        float3 fillL   = normalize(float3(-0.3, 0.5, -0.5));
+        float3 H       = normalize(V + fillL);
+        float3 radiance = float3(0.6, 0.7, 0.9) * 0.5;
+        float  NdotL   = max(dot(N, fillL), 0.0);
+        float  NdotV   = max(dot(N, V), 0.0);
+        float  D       = distributionGGX(N, H, roughness);
+        float  G       = geometrySmith(N, V, fillL, roughness);
+        float3 F       = fresnelSchlick(max(dot(H, V), 0.0), F0);
+        float3 specular = (D * G * F) / max(4.0 * NdotV * NdotL, 0.0001);
+        float3 kD      = (1.0 - F) * (1.0 - metallic);
+        float3 diffuse = kD * baseColor.rgb / PI;
+        Lo += (diffuse + specular) * radiance * NdotL;
+    }
+
+    // Ambient — sky/ground colours driven by the same procedural sky model.
+    float3 sunDir3     = normalize(-ubo.lightDir.xyz);
+    float3 skyColor    = evalSkyColor(float3(0.0, 1.0, 0.0), sunDir3); // zenith sky sample
+    float3 groundColor = evalGroundColor(sunDir3);                      // earth-toned lower lobe
+    float3 ambientL    = lerp(groundColor, skyColor, N.y * 0.5 + 0.5);
+    float3 kS          = fresnelSchlickRoughness(max(dot(N, V), 0.0), F0, roughness);
+    float3 kD_amb      = (1.0 - kS) * (1.0 - metallic);
+    float3 ambientContribution = (kD_amb * baseColor.rgb * ambientL + kS * ambientL * (1.0 - roughness * 0.5)) * ao * 0.3;
+
+    float3 finalColor = ambientContribution + Lo + emissive;
+    finalColor = acesTonemap(finalColor);
+
+    payload.color = finalColor;
+}

--- a/src/shaders/RT_Miss.slang
+++ b/src/shaders/RT_Miss.slang
@@ -1,0 +1,23 @@
+#include "ShaderCommon.slang"
+
+// Classic ray tracer RayPayload.
+struct RayPayload {
+    float3 color;
+    uint   isShadowed;
+};
+
+// Set 1 — global UBO (needed for lightDir → sun direction).
+[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
+
+[shader("miss")]
+void main(inout RayPayload payload) {
+    if (payload.isShadowed == 1) {
+        payload.isShadowed = 0;  // Not occluded — ray reached sky without hitting anything.
+        return;
+    }
+
+    float3 rayDir = normalize(WorldRayDirection());
+    float3 sunDir = normalize(-ubo.lightDir.xyz); // FROM scene TOWARD sun
+
+    payload.color = evalSkyColor(rayDir, sunDir);
+}

--- a/src/shaders/RT_Raygen.slang
+++ b/src/shaders/RT_Raygen.slang
@@ -1,0 +1,49 @@
+#include "ShaderCommon.slang"
+
+// Classic ray tracer RayPayload (simple shaded color + shadow flag).
+struct RayPayload {
+    float3 color;
+    uint   isShadowed;
+};
+
+// Set 0 — RT descriptor set (shared layout with path tracer).
+// Only bindings 0 and 1 are needed by the raygen shader itself.
+[[vk::binding(0, 0)]] RaytracingAccelerationStructure tlas;
+[[vk::binding(1, 0)]] RWTexture2D<float4> outputImage;
+
+// Set 1 — global UBO
+[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
+
+[shader("raygeneration")]
+void main() {
+    uint2 launchID   = DispatchRaysIndex().xy;
+    uint2 launchSize = DispatchRaysDimensions().xy;
+
+    float2 pixelCenter = float2(launchID) + float2(0.5, 0.5);
+    float2 inUV        = pixelCenter / float2(launchSize);
+    float2 d           = inUV * 2.0 - 1.0;
+
+    // Use precomputed inverse matrices from the UBO; inverse() is unavailable in SPIRV targets.
+    float4x4 invView = ubo.viewInverse;
+    float4x4 invProj = ubo.projInverse;
+
+    // Rasterizer uses a negative viewport height to flip Y (OpenGL style).
+    // We must mirror this mathematically in the Ray Tracer's NDC ray unprojection.
+    float4 target = mul(invProj, float4(d.x, -d.y, 1.0, 1.0));
+    float3 rayDir = mul(invView, float4(normalize(target.xyz / target.w), 0.0)).xyz;
+    float3 origin = ubo.cameraPos.xyz;
+
+    RayDesc ray;
+    ray.Origin    = origin;
+    ray.Direction = normalize(rayDir);
+    ray.TMin      = 0.001;
+    ray.TMax      = 10000.0;
+
+    RayPayload payload;
+    payload.color      = float3(0.0, 0.0, 0.0);
+    payload.isShadowed = 0;
+
+    TraceRay(tlas, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+
+    outputImage[launchID] = float4(payload.color, 1.0);
+}

--- a/src/shaders/Raygen.slang
+++ b/src/shaders/Raygen.slang
@@ -1,41 +1,203 @@
 #include "ShaderCommon.slang"
 
-[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
+// Path tracer RayPayload — surface properties returned by ClosestHit to Raygen.
+// hitT < 0 is the escape sentinel set by Miss to indicate a sky hit.
+// Total size: 3+3+3+3+1+1+3+1+1 floats × 4 = 19 × 4 = 76 bytes (within 128-byte limit).
+struct RayPayload {
+    float3 albedo;       // Linear base color × (1 - metallic) diffuse weight
+    float3 emission;     // Emissive radiance; Miss writes sky radiance here
+    float3 worldNormal;  // Shading normal in world space (after normal mapping)
+    float3 hitPos;       // World-space position of the surface hit
+    float  roughness;    // PBR roughness [MIN_ROUGHNESS, 1]
+    float  metallic;     // PBR metallic [0, 1]
+    float3 F0;           // Fresnel base reflectance (precomputed from albedo + metallic)
+    float  hitT;         // Ray t-value; negative means ray escaped to sky (Miss fired)
+    uint   instanceID;   // InstanceID() from ClosestHit; 0 on sky hit
+};
+
+// Set 0 — RT descriptor set
 [[vk::binding(0, 0)]] RaytracingAccelerationStructure tlas;
-[[vk::binding(1, 0)]] RWTexture2D<float4> outputImage;
+[[vk::binding(1, 0)]] RWTexture2D<float4> noisyColorOutput;   // 1 SPP raw radiance
+[[vk::binding(2, 0)]] RWTexture2D<float4> gBufferNormals;     // world-space normal (xyz), w unused
+[[vk::binding(3, 0)]] RWTexture2D<float>  gBufferDepth;       // linear ray hit distance (negative = sky)
+[[vk::binding(4, 0)]] RWTexture2D<float2> motionVectors;      // screen-space UV offset current→previous
 
-
+// Set 1 — global UBO
+[[vk::binding(0, 1)]] ConstantBuffer<UniformBuffer> ubo;
 
 [shader("raygeneration")]
 void main() {
-    uint2 launchID = DispatchRaysIndex().xy;
-    uint2 launchSize = DispatchRaysDimensions().xy;
+    uint2  launchID   = DispatchRaysIndex().xy;
+    uint2  launchSize = DispatchRaysDimensions().xy;
 
-    float2 pixelCenter = float2(launchID) + float2(0.5, 0.5);
-    float2 inUV = pixelCenter / float2(launchSize);
-    float2 d = inUV * 2.0 - 1.0;
-    // Use precomputed inverse matrices from the UBO; inverse() is unavailable in SPIRV targets.
-    float4x4 invView = ubo.viewInverse;
-    float4x4 invProj = ubo.projInverse;
+    // Per-pixel RNG seed: unique per pixel and per frame.
+    uint rngState = pcgHash(launchID.x + launchID.y * launchSize.x + ubo.frameCount * launchSize.x * launchSize.y);
 
-    // Rasterizer uses a negative viewport height to flip Y (OpenGL style).
-    // We must mirror this mathematically in the Ray Tracer's NDC ray unprojection. 
-    float4 target = mul(invProj, float4(d.x, -d.y, 1.0, 1.0));
-    float3 rayDir = mul(invView, float4(normalize(target.xyz / target.w), 0.0)).xyz;
+    // Sub-pixel jitter (disabled when jitter fields are zero; set to Halton values to enable TAA).
+    float2 pixelCenter = float2(launchID) + float2(0.5 + ubo.jitter_x, 0.5 + ubo.jitter_y);
+    float2 inUV        = pixelCenter / float2(launchSize);
+    float2 d           = inUV * 2.0 - 1.0;
+
+    float4 target = mul(ubo.projInverse, float4(d.x, -d.y, 1.0, 1.0));
+    float3 rayDir = mul(ubo.viewInverse, float4(normalize(target.xyz / target.w), 0.0)).xyz;
     float3 origin = ubo.cameraPos.xyz;
 
+    // ── Path tracing loop ──────────────────────────────────────────────────
+    float3 radiance   = float3(0.0, 0.0, 0.0);
+    float3 throughput = float3(1.0, 1.0, 1.0);
+
     RayDesc ray;
-    ray.Origin = origin;
+    ray.Origin    = origin;
     ray.Direction = normalize(rayDir);
-    ray.TMin = 0.001;
-    ray.TMax = 10000.0;
+    ray.TMin      = 0.001;
+    ray.TMax      = 10000.0;
 
-    RayPayload payload;
-    payload.color = float3(0.0, 0.0, 0.0);
-    payload.isShadowed = 0;
+    static const int MAX_BOUNCES = 3;
 
-    // Call TraceRay
-    TraceRay(tlas, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+    for (int bounce = 0; bounce < MAX_BOUNCES; ++bounce)
+    {
+        RayPayload payload;
+        payload.hitT = -1.0;
 
-    outputImage[launchID] = float4(payload.color, 1.0);
+        TraceRay(tlas, RAY_FLAG_NONE, 0xFF, 0, 0, 0, ray, payload);
+
+        // Sky miss: accumulate background emission and terminate.
+        if (payload.hitT < 0.0) {
+            radiance += throughput * payload.emission;
+            // Write sentinel G-Buffer values so sky pixels don't leave stale/garbage data
+            // that would confuse the denoiser's edge-stopping functions.
+            if (bounce == 0) {
+                gBufferNormals[launchID] = float4(0.0, 0.0, 0.0, 0.0);
+                gBufferDepth[launchID]   = -1.0;
+                motionVectors[launchID]  = float2(0.0, 0.0);
+            }
+            break;
+        }
+
+        // Accumulate emissive contribution from the surface.
+        radiance += throughput * payload.emission;
+
+        // ── NEE: direct lighting from directional sun light ────────────────
+        // ubo.lightDir points FROM the light TOWARD the scene, so negate for surface-to-light.
+        float3 Ldir  = normalize(-ubo.lightDir.xyz);
+        float  NdotL = max(dot(payload.worldNormal, Ldir), 0.0);
+        if (NdotL > 0.0)
+        {
+            // Cheap occlusion ray: skip ClosestHit, terminate on first accepted hit.
+            RayPayload shadowPayload;
+            shadowPayload.hitT        = 1.0;   // positive sentinel = "occluded"; Miss sets it to -1
+            shadowPayload.albedo      = float3(0.0, 0.0, 0.0);
+            shadowPayload.emission    = float3(0.0, 0.0, 0.0);
+            shadowPayload.worldNormal = float3(0.0, 1.0, 0.0);
+            shadowPayload.hitPos      = float3(0.0, 0.0, 0.0);
+            shadowPayload.roughness   = 1.0;
+            shadowPayload.metallic    = 0.0;
+            shadowPayload.F0          = float3(0.0, 0.0, 0.0);
+            shadowPayload.instanceID  = 0;
+
+            RayDesc shadowRay;
+            shadowRay.Origin    = payload.hitPos + payload.worldNormal * 0.002;
+            shadowRay.Direction = Ldir;
+            shadowRay.TMin      = 0.001;
+            shadowRay.TMax      = 10000.0;
+            TraceRay(tlas,
+                RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER,
+                0xFF, 0, 0, 0, shadowRay, shadowPayload);
+
+            // hitT < 0 means Miss fired → surface is unoccluded.
+            if (shadowPayload.hitT < 0.0)
+            {
+                float3 V2    = -ray.Direction;
+                float3 N2    = payload.worldNormal;
+                float3 H     = normalize(Ldir + V2);
+                float  NdotV = max(dot(N2, V2),   0.0001);
+                float  VdotH = max(dot(V2, H),    0.0001);
+
+                float3 Fs   = fresnelSchlick(VdotH, payload.F0);
+                float  D    = distributionGGX(N2, H, payload.roughness);
+                float  G    = geometrySmith(N2, V2, Ldir, payload.roughness);
+                float3 kD   = (float3(1.0, 1.0, 1.0) - Fs) * (1.0 - payload.metallic);
+
+                float3 diffuse  = kD * payload.albedo / PI;
+                float3 specular = (D * Fs * G) / max(4.0 * NdotV * NdotL, 0.0001);
+
+                float3 sunRadiance = float3(3.0, 2.8, 2.5);  // warm white directional light
+                radiance += throughput * (diffuse + specular) * NdotL * sunRadiance;
+            }
+        }
+
+        // ── Primary-ray G-Buffer write (bounce 0 only) ─────────────────────
+        if (bounce == 0) {
+            gBufferNormals[launchID] = float4(payload.worldNormal, 0.0);
+            gBufferDepth[launchID]   = payload.hitT;
+
+            // Motion vector: re-project hit world position with previous frame VP.
+            float4 prevClip = mul(ubo.prevViewProj, float4(payload.hitPos, 1.0));
+            // GLM proj is Y-up NDC: prevClip.y/w = +(1 - 2*v) where v=0 at top.
+            // Convert to image UV (Y-down, v=0 at top) by negating Y, matching the
+            // -d.y correction used in primary ray generation.
+            float2 prevNDC  = (prevClip.xy / prevClip.w) * float2(0.5, -0.5) + 0.5;
+            // Use unjittered UV so TAA jitter doesn't appear as false motion in the denoiser.
+            float2 unjitteredUV = (float2(launchID) + 0.5) / float2(launchSize);
+            motionVectors[launchID] = unjitteredUV - prevNDC;
+        }
+
+        // ── BSDF sampling ──────────────────────────────────────────────────
+        float3 N = payload.worldNormal;
+        float3 V = -ray.Direction;
+
+        float2 xi = float2(randomFloat(rngState), randomFloat(rngState));
+
+        // Probabilistically choose diffuse vs specular lobe based on Fresnel reflectance.
+        float3 F       = fresnelSchlick(max(dot(N, V), 0.0), payload.F0);
+        float  fAvg    = (F.r + F.g + F.b) / 3.0;
+        float  specProb = clamp(fAvg + payload.metallic * 0.5, 0.1, 0.9);
+
+        float3 newDir;
+        float  pdf;
+        float3 bsdfWeight;
+
+        if (randomFloat(rngState) < specProb) {
+            // Specular (GGX) lobe
+            newDir = ggxSampleDirection(xi, N, V, payload.roughness);
+            float NdotL = max(dot(N, newDir), 0.0);
+            if (NdotL <= 0.0) break;
+
+            float3 H    = normalize(V + newDir);
+            float  G    = geometrySmith(N, V, newDir, payload.roughness);
+            float3 Fs   = fresnelSchlick(max(dot(H, V), 0.0), payload.F0);
+            float  NdotV = max(dot(N, V),    0.0001);
+            float  NdotH = max(dot(N, H),    0.0001);
+            float  VdotH = max(dot(V, H),    0.0001);
+            bsdfWeight   = (G * Fs * VdotH) / max(NdotV * NdotH, 0.0001);
+            pdf          = specProb;
+        } else {
+            // Diffuse (cosine hemisphere) lobe — cosine factor cancels with PDF.
+            newDir = cosineSampleHemisphere(xi, N);
+            if (max(dot(N, newDir), 0.0) <= 0.0) break;
+
+            float3 kD  = (float3(1.0, 1.0, 1.0) - F) * (1.0 - payload.metallic);
+            bsdfWeight = kD * payload.albedo;
+            pdf        = 1.0 - specProb;
+        }
+
+        throughput *= bsdfWeight / max(pdf, 0.0001);
+
+        // Russian roulette: stochastic early termination after first bounce.
+        if (bounce >= 1) {
+            float maxT  = max(throughput.r, max(throughput.g, throughput.b));
+            float rrProb = clamp(maxT, 0.01, 0.95); // clamp away from 0 to prevent 0/0 NaN
+            if (randomFloat(rngState) > rrProb) break;
+            throughput /= rrProb;
+        }
+
+        // Advance ray — offset origin along geometric normal to avoid self-intersection.
+        ray.Origin    = payload.hitPos + payload.worldNormal * 0.001;
+        ray.Direction = normalize(newDir);
+        ray.TMin      = 0.001;
+        ray.TMax      = 10000.0;
+    }
+
+    // Write noisy 1-SPP result — linear HDR, tone mapping is applied in the final A-Trous pass.
+    noisyColorOutput[launchID] = float4(radiance, 1.0);
 }

--- a/src/shaders/Reprojection.slang
+++ b/src/shaders/Reprojection.slang
@@ -1,0 +1,92 @@
+#include "ShaderCommon.slang"
+
+// Denoiser descriptor set (Set 0) — all bindings are storage images.
+[[vk::binding(0,  0)]] RWTexture2D<float4> noisyColor;           // current noisy 1-SPP input
+[[vk::binding(1,  0)]] RWTexture2D<float4> gBufferNormals;       // current G-Buffer normals
+[[vk::binding(2,  0)]] RWTexture2D<float>  gBufferDepth;         // current G-Buffer depth
+[[vk::binding(3,  0)]] RWTexture2D<float2> motionVectors;        // current motion vectors
+[[vk::binding(4,  0)]] RWTexture2D<float4> historyColorIn;       // previous frame colour history (read)
+[[vk::binding(5,  0)]] RWTexture2D<float4> historyColorOut;      // this frame colour history (write)
+[[vk::binding(6,  0)]] RWTexture2D<float2> historyMomentsIn;     // previous frame moments (read)
+[[vk::binding(7,  0)]] RWTexture2D<float2> historyMomentsOut;    // this frame moments (write)
+[[vk::binding(8,  0)]] RWTexture2D<float4> atrousTempA;          // A-Trous ping-pong A (reprojection writes here)
+// bindings 9, 10 unused in this shader
+[[vk::binding(11, 0)]] RWTexture2D<float4> prevGBufferNormals;   // previous-frame G-Buffer normals
+[[vk::binding(12, 0)]] RWTexture2D<float>  prevGBufferDepth;     // previous-frame G-Buffer depth
+
+// Push constants (shared layout with A-Trous; stepSize == 0 identifies this pass)
+struct DenoisePushConstants {
+    int   stepSize;
+    int   isLastPass;
+    float phiColor;
+    float phiNormal;
+};
+[[vk::push_constant]] DenoisePushConstants push;
+
+float luminance(float3 c) { return dot(c, float3(0.2126, 0.7152, 0.0722)); }
+
+[shader("compute")]
+[numthreads(16, 16, 1)]
+void reprojectionMain(uint3 dispatchID : SV_DispatchThreadID)
+{
+    uint2 dims;
+    noisyColor.GetDimensions(dims.x, dims.y);
+    uint2 pixel = dispatchID.xy;
+    if (pixel.x >= dims.x || pixel.y >= dims.y) return;
+
+    float3 currentColor  = noisyColor[pixel].rgb;
+    float3 currentNormal = gBufferNormals[pixel].xyz;
+    float  currentDepth  = gBufferDepth[pixel];
+
+    // ── Firefly suppression: clamp outlier luminance before temporal blend ───
+    float currentLum = luminance(currentColor);
+    float2 prevMomentsVal = historyMomentsIn[pixel];
+    float  prevMean       = prevMomentsVal.x;
+    float  prevVar        = max(prevMomentsVal.y - prevMean * prevMean, 0.0);
+    float  sigma          = sqrt(prevVar);
+    float  clampMax       = prevMean + 4.0 * sigma;
+    if (prevVar > 0.001 && currentLum > clampMax)
+        currentColor *= clampMax / max(currentLum, 0.0001);
+
+    // ── Temporal reprojection ────────────────────────────────────────────────
+    // mv = currentCenterUV - prevCenterUV, where centerUV = (pixel + 0.5) / dims.
+    // Rearranged: prevPixelIndex = floor(pixel + 0.5 - mv*dims - 0.5) = floor(pixel - mv*dims).
+    // The old code subtracted an extra 0.5 on top of the correct derivation, shifting
+    // every lookup one pixel up-left and breaking accumulation even for a static camera.
+    float2 mv        = motionVectors[pixel];
+    int2   prevPixel = int2(float2(pixel) - mv * float2(dims));
+
+    // Rejection heuristics: normals must align and depths must be close.
+    bool   valid = all(prevPixel >= int2(0, 0)) && all(prevPixel < int2(dims));
+    float3 histColor = float3(0.0, 0.0, 0.0);
+    float  alpha     = 1.0;   // 1.0 = trust only current (no history)
+
+    if (valid) {
+        float3 prevNormal = prevGBufferNormals[prevPixel].xyz;
+        float  prevDepth  = prevGBufferDepth[prevPixel];
+
+        float normalDot   = dot(normalize(currentNormal), normalize(prevNormal));
+        float depthRelErr = abs(currentDepth - prevDepth) / max(abs(currentDepth), 0.001);
+
+        if (normalDot > 0.9 && depthRelErr < 0.1 && currentDepth > 0.0 && prevDepth > 0.0) {
+            histColor = historyColorIn[prevPixel].rgb;
+            // push.phiColor carries historyAlpha from C++:
+            //   0.1 when camera is static  → blend 10% current / 90% history for fast convergence
+            //   1.0 when camera moved      → discard history entirely to prevent ghosting bands
+            alpha = push.phiColor;
+        }
+    }
+
+    float3 blended = lerp(histColor, currentColor, alpha);
+
+    // ── Temporal moments (mean and mean²) for variance estimation ────────────
+    float blendedLum = luminance(blended);
+    float2 prevMom   = valid ? historyMomentsIn[prevPixel] : float2(0.0, 0.0);
+    float  newMean   = lerp(prevMom.x, blendedLum, alpha);
+    float  newMean2  = lerp(prevMom.y, blendedLum * blendedLum, alpha);
+
+    // ── Write outputs ────────────────────────────────────────────────────────
+    atrousTempA[pixel]        = float4(blended, 1.0);   // A-Trous input for first iteration
+    historyColorOut[pixel]    = float4(blended, 1.0);   // history for next frame
+    historyMomentsOut[pixel]  = float2(newMean, newMean2);
+}

--- a/src/shaders/ShaderCommon.slang
+++ b/src/shaders/ShaderCommon.slang
@@ -1,111 +1,44 @@
 #ifndef SHADER_COMMON_H
 #define SHADER_COMMON_H
 
-static const float PI = 3.14159265359;
+static const float PI          = 3.14159265359;
 static const float MIN_ROUGHNESS = 0.04;
 
-struct RayPayload {
-    float3 color;
-    uint isShadowed;
-};
-
 // ============================================================================
-// PBR Functions
+// NOTE: RayPayload is defined per-pipeline in each shader set:
+//   - Classic RT (RT_Raygen.slang etc.): struct RayPayload { float3 color; uint isShadowed; }
+//   - Path Tracer (Raygen.slang etc.):   struct RayPayload { float3 albedo; ...; float hitT; uint instanceID; }
 // ============================================================================
-
-float distributionGGX(float3 N, float3 H, float roughness) {
-    float a = roughness * roughness;
-    float a2 = a * a;
-    float NdotH = max(dot(N, H), 0.0);
-    float NdotH2 = NdotH * NdotH;
-    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
-    denom = PI * denom * denom;
-    return a2 / max(denom, 0.0001);
-}
-
-float geometrySchlickGGX(float NdotV, float roughness) {
-    float r = roughness + 1.0;
-    float k = (r * r) / 8.0;
-    return NdotV / (NdotV * (1.0 - k) + k);
-}
-
-float geometrySmith(float3 N, float3 V, float3 L, float roughness) {
-    float NdotV = max(dot(N, V), 0.0);
-    float NdotL = max(dot(N, L), 0.0);
-    return geometrySchlickGGX(NdotV, roughness) * geometrySchlickGGX(NdotL, roughness);
-}
-
-float3 fresnelSchlick(float cosTheta, float3 F0) {
-    return F0 + (1.0 - F0) * pow(saturate(1.0 - cosTheta), 5.0);
-}
-
-float3 fresnelSchlickRoughness(float cosTheta, float3 F0, float roughness) {
-    float3 maxRefl = max(float3(1.0 - roughness, 1.0 - roughness, 1.0 - roughness), F0);
-    return F0 + (maxRefl - F0) * pow(saturate(1.0 - cosTheta), 5.0);
-}
-
-float3 sRGBToLinear(float3 srgb) {
-    return pow(srgb, float3(2.2, 2.2, 2.2));
-}
-
-float3 linearToSRGB(float3 linear) {
-    return pow(linear, float3(1.0 / 2.2, 1.0 / 2.2, 1.0 / 2.2));
-}
-
-float3 acesTonemap(float3 x) {
-    float a = 2.51;
-    float b = 0.03;
-    float c = 2.43;
-    float d = 0.59;
-    float e = 0.14;
-    return saturate((x * (a * x + b)) / (x * (c * x + d) + e));
-}
-
-// 3x3 matrix inverse via cofactor expansion (SPIRV does not expose a built-in inverse).
-float3x3 mat3Inverse(float3x3 m) {
-    float a = m[0][0], b = m[0][1], c = m[0][2];
-    float d = m[1][0], e = m[1][1], f = m[1][2];
-    float g = m[2][0], h = m[2][1], i = m[2][2];
-
-    float det = a * (e * i - f * h)
-              - b * (d * i - f * g)
-              + c * (d * h - e * g);
-
-    float invDet = 1.0 / det;
-
-    // adjugate transposed (= inverse * det)
-    float3x3 inv;
-    inv[0][0] =  (e * i - f * h) * invDet;
-    inv[0][1] = -(b * i - c * h) * invDet;
-    inv[0][2] =  (b * f - c * e) * invDet;
-    inv[1][0] = -(d * i - f * g) * invDet;
-    inv[1][1] =  (a * i - c * g) * invDet;
-    inv[1][2] = -(a * f - c * d) * invDet;
-    inv[2][0] =  (d * h - e * g) * invDet;
-    inv[2][1] = -(a * h - b * g) * invDet;
-    inv[2][2] =  (a * e - b * d) * invDet;
-    return inv;
-}
-
-
+// Uniform Buffer — must mirror UniformBufferObject in EngineAuxiliary.h exactly.
+// ============================================================================
 struct UniformBuffer {
     float4x4 view;
     float4x4 proj;
-    float4 cameraPos;
-    float4 lightDir;
+    float4   cameraPos;
+    float4   lightDir;
 
     float4x4 viewInverse;
     float4x4 projInverse;
 
-    // Cascaded Shadow Map — split depths (positive view-space distances) and per-cascade light VP
+    // Cascaded Shadow Map (used by rasterizer path only; still present for struct compatibility)
     float4   cascadeSplits;
     float4x4 cascadeViewProj[4];
+
+    // Path tracer temporal fields
+    float4x4 prevViewProj;   // Previous frame combined VP for motion vector reprojection
+    uint     frameCount;     // Monotonically increasing RNG seed
+    float    jitter_x;       // Sub-pixel x jitter in NDC (zero when disabled)
+    float    jitter_y;       // Sub-pixel y jitter in NDC
+    uint     _pad0;
 };
 
+// ============================================================================
+// Rasterizer structs (unchanged)
+// ============================================================================
 struct ScenePushConstants {
     float4x4 modelMatrix;
     int materialIndex;
-    int cascadeIndex;   // which CSM cascade is rendered (shadow pass); unused padding for main pass
+    int cascadeIndex;   // which CSM cascade is rendered (shadow pass); unused in main pass
     int padding2;
     int padding3;
     float4 skyData; // xyz = color, w = threshold
@@ -148,5 +81,179 @@ struct Vertex {
     float2 texCoord;
     float3 color;
 };
+
+// ============================================================================
+// PBR Math — kept intact; Raygen uses these for GGX importance sampling.
+// ============================================================================
+
+float distributionGGX(float3 N, float3 H, float roughness) {
+    float a = roughness * roughness;
+    float a2 = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH * NdotH;
+    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+    denom = PI * denom * denom;
+    return a2 / max(denom, 0.0001);
+}
+
+float geometrySchlickGGX(float NdotV, float roughness) {
+    float r = roughness + 1.0;
+    float k = (r * r) / 8.0;
+    return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+float geometrySmith(float3 N, float3 V, float3 L, float roughness) {
+    float NdotV = max(dot(N, V), 0.0);
+    float NdotL = max(dot(N, L), 0.0);
+    return geometrySchlickGGX(NdotV, roughness) * geometrySchlickGGX(NdotL, roughness);
+}
+
+float3 fresnelSchlick(float cosTheta, float3 F0) {
+    return F0 + (1.0 - F0) * pow(saturate(1.0 - cosTheta), 5.0);
+}
+
+float3 fresnelSchlickRoughness(float cosTheta, float3 F0, float roughness) {
+    float3 maxRefl = max(float3(1.0 - roughness, 1.0 - roughness, 1.0 - roughness), F0);
+    return F0 + (maxRefl - F0) * pow(saturate(1.0 - cosTheta), 5.0);
+}
+
+float3 sRGBToLinear(float3 srgb) {
+    return pow(srgb, float3(2.2, 2.2, 2.2));
+}
+
+float3 linearToSRGB(float3 linear) {
+    return pow(max(linear, float3(0.0, 0.0, 0.0)), float3(1.0 / 2.2, 1.0 / 2.2, 1.0 / 2.2));
+}
+
+// Procedural sky radiance for a given view direction and sun direction.
+// sunDir = normalize(-lightDir) — the vector pointing FROM the scene TOWARD the sun.
+// Used by Miss shaders (background), and evaluated at zenith/nadir for ambient terms.
+float3 evalSkyColor(float3 rayDir, float3 sunDir) {
+    // Vertical gradient: 0 at/below horizon, 1 at zenith.
+    float skyT         = clamp(rayDir.y * 0.5 + 0.5, 0.0, 1.0);
+    float sunElevation = sunDir.y; // -1 = fully below horizon, +1 = directly overhead
+
+    // Colour palettes (linear HDR).
+    float3 dayZenith     = float3(0.15, 0.35, 0.75);
+    float3 dayHorizon    = float3(0.50, 0.65, 0.88);
+    float3 sunsetZenith  = float3(0.12, 0.18, 0.45);
+    float3 sunsetHorizon = float3(0.90, 0.42, 0.08);
+    float3 nightZenith   = float3(0.005, 0.006, 0.020);
+    float3 nightHorizon  = float3(0.008, 0.009, 0.015);
+
+    // dayFactor:    0 when sun is at/below horizon, ramps to 1 at ~24° elevation.
+    // sunsetFactor: peaks at 1 when sun is on the horizon, falls off on both sides.
+    float dayFactor    = clamp(sunElevation * 2.5,            0.0, 1.0);
+    float sunsetFactor = clamp(1.0 - abs(sunElevation) * 5.0, 0.0, 1.0);
+
+    float3 zenithColor  = lerp(lerp(nightZenith,  sunsetZenith,  sunsetFactor), dayZenith,  dayFactor);
+    float3 horizonColor = lerp(lerp(nightHorizon, sunsetHorizon, sunsetFactor), dayHorizon, dayFactor);
+
+    // Quadratic vertical gradient for a natural sky-dome falloff.
+    return lerp(horizonColor, zenithColor, skyT * skyT);
+}
+
+// Ground-bounce colour for the ambient hemisphere lower lobe.
+// Represents diffuse irradiance reflected up from the terrain — always earth-toned,
+// never sky-coloured. sunDir = normalize(-lightDir).
+float3 evalGroundColor(float3 sunDir) {
+    float sunElevation = sunDir.y;
+    float dayFactor    = clamp(sunElevation * 2.5,            0.0, 1.0);
+    float sunsetFactor = clamp(1.0 - abs(sunElevation) * 5.0, 0.0, 1.0);
+
+    float3 dayGround    = float3(0.10, 0.08, 0.06);   // sun-lit warm earth
+    float3 sunsetGround = float3(0.14, 0.08, 0.04);   // slightly warm-tinted at dusk/dawn
+    float3 nightGround  = float3(0.005, 0.004, 0.003); // near-black at night
+
+    return lerp(lerp(nightGround, sunsetGround, sunsetFactor), dayGround, dayFactor);
+}
+
+float3 acesTonemap(float3 x) {
+    float a = 2.51;
+    float b = 0.03;
+    float c = 2.43;
+    float d = 0.59;
+    float e = 0.14;
+    return saturate((x * (a * x + b)) / (x * (c * x + d) + e));
+}
+
+// 3x3 matrix inverse via cofactor expansion (SPIRV has no built-in inverse).
+float3x3 mat3Inverse(float3x3 m) {
+    float a = m[0][0], b = m[0][1], c = m[0][2];
+    float d = m[1][0], e = m[1][1], f = m[1][2];
+    float g = m[2][0], h = m[2][1], i = m[2][2];
+
+    float det = a * (e * i - f * h)
+              - b * (d * i - f * g)
+              + c * (d * h - e * g);
+
+    float invDet = 1.0 / det;
+
+    float3x3 inv;
+    inv[0][0] =  (e * i - f * h) * invDet;
+    inv[0][1] = -(b * i - c * h) * invDet;
+    inv[0][2] =  (b * f - c * e) * invDet;
+    inv[1][0] = -(d * i - f * g) * invDet;
+    inv[1][1] =  (a * i - c * g) * invDet;
+    inv[1][2] = -(a * f - c * d) * invDet;
+    inv[2][0] =  (d * h - e * g) * invDet;
+    inv[2][1] = -(a * h - b * g) * invDet;
+    inv[2][2] =  (a * e - b * d) * invDet;
+    return inv;
+}
+
+// ============================================================================
+// Random Number Generation — PCG hash, seeded by pixel index and frame count.
+// ============================================================================
+
+uint pcgHash(uint seed) {
+    uint state = seed * 747796405u + 2891336453u;
+    uint word  = ((state >> ((state >> 28u) + 4u)) ^ state) * 277803737u;
+    return (word >> 22u) ^ word;
+}
+
+// Advance RNG state and return a uniform float in [0, 1).
+float randomFloat(inout uint seed) {
+    seed = pcgHash(seed);
+    return float(seed) / 4294967296.0;
+}
+
+// ============================================================================
+// Sampling — cosine-weighted hemisphere and GGX reflection.
+// ============================================================================
+
+// Cosine-weighted sample on the hemisphere oriented around N.
+// xi: two uniform random numbers in [0, 1).
+float3 cosineSampleHemisphere(float2 xi, float3 N) {
+    float r   = sqrt(xi.x);
+    float phi = 2.0 * PI * xi.y;
+
+    // Local tangent frame
+    float3 up      = abs(N.y) < 0.999 ? float3(0.0, 1.0, 0.0) : float3(1.0, 0.0, 0.0);
+    float3 tangent  = normalize(cross(up, N));
+    float3 bitangent = cross(N, tangent);
+
+    float3 localDir = float3(r * cos(phi), sqrt(max(0.0, 1.0 - xi.x)), r * sin(phi));
+    return normalize(tangent * localDir.x + N * localDir.y + bitangent * localDir.z);
+}
+
+// GGX-importance-sampled microfacet normal (half-vector), then reflect incident ray.
+// Returns the sampled outgoing direction. xi: two uniform random numbers.
+float3 ggxSampleDirection(float2 xi, float3 N, float3 V, float roughness) {
+    float a = roughness * roughness;
+
+    float phi      = 2.0 * PI * xi.x;
+    float cosTheta = sqrt((1.0 - xi.y) / max(1.0 + (a * a - 1.0) * xi.y, 0.0001));
+    float sinTheta = sqrt(max(0.0, 1.0 - cosTheta * cosTheta));
+
+    float3 up       = abs(N.y) < 0.999 ? float3(0.0, 1.0, 0.0) : float3(1.0, 0.0, 0.0);
+    float3 tangent  = normalize(cross(up, N));
+    float3 bitangent = cross(N, tangent);
+
+    float3 H = normalize(tangent * (sinTheta * cos(phi)) +
+                         N       *  cosTheta              +
+                         bitangent * (sinTheta * sin(phi)));
+    return reflect(-V, H);
+}
 
 #endif // SHADER_COMMON_H


### PR DESCRIPTION
Adds a path-tracing backend and a refactored classic ray-tracer pipeline, replacing the useRayTracing bool with a three-way RenderMode enum (Rasterizer / RayTracer / PathTracer):

- **Path tracer (PathTracer mode)** — 1 SPP BRDF-sampled multi-bounce path tracer with Russian roulette termination; writes a G-Buffer (normals, linear depth, motion vectors) each frame
- **Temporal reprojection** — re-projects previous frame colour/moments via motion vectors; exponential history blend with depth-based disocclusion rejection; history reset on camera cut
- **A-Trous spatial denoiser** — 5-pass edge-stopping wavelet filter (luminance + normal + depth weights); ping-pong between two R16G16B16A16 buffers
- **Classic ray tracer (RayTracer mode)** — separate classicRTPipeline / RT_*.slang shaders; one primary ray + one shadow ray, direct illumination only, no bounces
- **New shaders** — RT_Raygen, RT_ClosestHit, RT_AnyHit, RT_Miss, Reprojection, Denoiser